### PR TITLE
Refactor Fedora yum repo file creation

### DIFF
--- a/build/templates/MEGAsync/megasync.spec
+++ b/build/templates/MEGAsync/megasync.spec
@@ -195,109 +195,19 @@ enabled=1
 DATA
 %endif
 
-%if 0%{?fedora_version} == 26
-# Fedora 26
+%if 0%{?fedora}
+# Fedora
 YUM_FILE="/etc/yum.repos.d/megasync.repo"
 cat > "$YUM_FILE" << DATA
 [MEGAsync]
 name=MEGAsync
-baseurl=https://mega.nz/linux/MEGAsync/Fedora_26/
-gpgkey=https://mega.nz/linux/MEGAsync/Fedora_26/repodata/repomd.xml.key
+baseurl=https://mega.nz/linux/MEGAsync/Fedora_\$releasever/
+gpgkey=https://mega.nz/linux/MEGAsync/Fedora_\$releasever/repodata/repomd.xml.key
 gpgcheck=1
 enabled=1
 DATA
 %endif
 
-%if 0%{?fedora_version} == 25
-# Fedora 25
-YUM_FILE="/etc/yum.repos.d/megasync.repo"
-cat > "$YUM_FILE" << DATA
-[MEGAsync]
-name=MEGAsync
-baseurl=https://mega.nz/linux/MEGAsync/Fedora_25/
-gpgkey=https://mega.nz/linux/MEGAsync/Fedora_25/repodata/repomd.xml.key
-gpgcheck=1
-enabled=1
-DATA
-%endif
-
-%if 0%{?fedora_version} == 24
-# Fedora 24
-YUM_FILE="/etc/yum.repos.d/megasync.repo"
-cat > "$YUM_FILE" << DATA
-[MEGAsync]
-name=MEGAsync
-baseurl=https://mega.nz/linux/MEGAsync/Fedora_24/
-gpgkey=https://mega.nz/linux/MEGAsync/Fedora_24/repodata/repomd.xml.key
-gpgcheck=1
-enabled=1
-DATA
-%endif
-
-%if 0%{?fedora_version} == 23
-# Fedora 23
-YUM_FILE="/etc/yum.repos.d/megasync.repo"
-cat > "$YUM_FILE" << DATA
-[MEGAsync]
-name=MEGAsync
-baseurl=https://mega.nz/linux/MEGAsync/Fedora_23/
-gpgkey=https://mega.nz/linux/MEGAsync/Fedora_23/repodata/repomd.xml.key
-gpgcheck=1
-enabled=1
-DATA
-%endif
-
-%if 0%{?fedora_version} == 22
-# Fedora 22
-YUM_FILE="/etc/yum.repos.d/megasync.repo"
-cat > "$YUM_FILE" << DATA
-[MEGAsync]
-name=MEGAsync
-baseurl=https://mega.nz/linux/MEGAsync/Fedora_22/
-gpgkey=https://mega.nz/linux/MEGAsync/Fedora_22/repodata/repomd.xml.key
-gpgcheck=1
-enabled=1
-DATA
-%endif
-
-%if 0%{?fedora_version} == 21
-# Fedora 21
-YUM_FILE="/etc/yum.repos.d/megasync.repo"
-cat > "$YUM_FILE" << DATA
-[MEGAsync]
-name=MEGAsync
-baseurl=https://mega.nz/linux/MEGAsync/Fedora_21/
-gpgkey=https://mega.nz/linux/MEGAsync/Fedora_21/repodata/repomd.xml.key
-gpgcheck=1
-enabled=1
-DATA
-%endif
-
-%if 0%{?fedora_version} == 20
-# Fedora 20
-YUM_FILE="/etc/yum.repos.d/megasync.repo"
-cat > "$YUM_FILE" << DATA
-[MEGAsync]
-name=MEGAsync
-baseurl=https://mega.nz/linux/MEGAsync/Fedora_20/
-gpgkey=https://mega.nz/linux/MEGAsync/Fedora_20/repodata/repomd.xml.key
-gpgcheck=1
-enabled=1
-DATA
-%endif
-
-%if 0%{?fedora_version} == 19
-# Fedora 19
-YUM_FILE="/etc/yum.repos.d/megasync.repo"
-cat > "$YUM_FILE" << DATA
-[MEGAsync]
-name=MEGAsync
-baseurl=https://mega.nz/linux/MEGAsync/Fedora_19
-gpgkey=https://mega.nz/linux/MEGAsync/Fedora_19/repodata/repomd.xml.key
-gpgcheck=1
-enabled=1
-DATA
-%endif
 
 %if 0%{?sle_version} == 120200
 # openSUSE Leap 42.2


### PR DESCRIPTION
Fedora (and other RPM-based distros I believe) can use some variables like in their yum repo files. For example here is the basic `fedora.repo`:
```ini
[fedora]
name=Fedora $releasever - $basearch
failovermethod=priority
#baseurl=http://download.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/$basearch/os/
metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
enabled=1
metadata_expire=7d
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
skip_if_unavailable=False

[fedora-debuginfo]
name=Fedora $releasever - $basearch - Debug
failovermethod=priority
#baseurl=http://download.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/$basearch/debug/
metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch
enabled=0
metadata_expire=7d
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
skip_if_unavailable=False

[fedora-source]
name=Fedora $releasever - Source
failovermethod=priority
#baseurl=http://download.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/source/tree/
metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch
enabled=0
metadata_expire=7d
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
skip_if_unavailable=False
```

Using the `$releasever` variable can both simplify the specfile to make RPMs, and ensure the correct repository is used regardless version changing because of system upgrades and such.

I don't know if this refactoring can be done with other distros, but I think it's probably possible.