### PR TITLE
Remove static due to build error

### DIFF
--- a/src/MEGASync/google_breakpad/client/linux/handler/exception_handler.cc
+++ b/src/MEGASync/google_breakpad/client/linux/handler/exception_handler.cc
@@ -104,7 +104,7 @@
 #endif
 
 // A wrapper for the tgkill syscall: send a signal to a specific thread.
-static int tgkill(pid_t tgid, pid_t tid, int sig) {
+int tgkill(pid_t tgid, pid_t tid, int sig) {
   return syscall(__NR_tgkill, tgid, tid, sig);
   return 0;
 }


### PR DESCRIPTION
Need to remove static because of build error in current Fedora rawhide:
google_breakpad/client/linux/handler/exception_handler.cc:107:12: error: 'int tgkill(pid_t, pid_t, int)' was declared 'extern' and later 'static' [-fpermissive]