### PR TITLE
Replace QString::fromAscii by QString::fromLatin1

### DIFF
--- a/src/MEGASync/MegaApplication.cpp
+++ b/src/MEGASync/MegaApplication.cpp
@@ -172,9 +172,9 @@ void setScreenScaleFactorsEnvVar(const QMap<QString, double> &screenscales)
     {
         if (scale_factors.size())
         {
-            scale_factors += QString::fromAscii(";");
+            scale_factors += QString::fromLatin1(";");
         }
-        scale_factors += ss.key() + QString::fromAscii("=") + QString::number(ss.value());
+        scale_factors += ss.key() + QString::fromLatin1("=") + QString::number(ss.value());
     }
 
     if (scale_factors.size())
@@ -426,19 +426,19 @@ int main(int argc, char *argv[])
 #endif
 
     QDir dataDir(app.applicationDataPath());
-    QString crashPath = dataDir.filePath(QString::fromAscii("crashDumps"));
-    QString avatarPath = dataDir.filePath(QString::fromAscii("avatars"));
-    QString appLockPath = dataDir.filePath(QString::fromAscii("megasync.lock"));
+    QString crashPath = dataDir.filePath(QString::fromLatin1("crashDumps"));
+    QString avatarPath = dataDir.filePath(QString::fromLatin1("avatars"));
+    QString appLockPath = dataDir.filePath(QString::fromLatin1("megasync.lock"));
     QDir crashDir(crashPath);
     if (!crashDir.exists())
     {
-        crashDir.mkpath(QString::fromAscii("."));
+        crashDir.mkpath(QString::fromLatin1("."));
     }
 
     QDir avatarsDir(avatarPath);
     if (!avatarsDir.exists())
     {
-        avatarsDir.mkpath(QString::fromAscii("."));
+        avatarsDir.mkpath(QString::fromLatin1("."));
     }
 
 #ifndef DEBUG
@@ -466,7 +466,7 @@ int main(int argc, char *argv[])
 
                     #ifdef WIN32
                         QString debrisPath = QDir::toNativeSeparators(preferences->getLocalFolder(j) +
-                                QDir::separator() + QString::fromAscii(MEGA_DEBRIS_FOLDER));
+                                QDir::separator() + QString::fromLatin1(MEGA_DEBRIS_FOLDER));
 
                         WIN32_FILE_ATTRIBUTE_DATA fad;
                         if (GetFileAttributesExW((LPCWSTR)debrisPath.utf16(), GetFileExInfoStandard, &fad))
@@ -530,7 +530,7 @@ int main(int argc, char *argv[])
         }
         else if (i == 0)
         {
-             QString appShowInterfacePath = dataDir.filePath(QString::fromAscii("megasync.show"));
+             QString appShowInterfacePath = dataDir.filePath(QString::fromLatin1("megasync.show"));
              QFile fappShowInterfacePath(appShowInterfacePath);
              if (fappShowInterfacePath.open(QIODevice::WriteOnly))
              {
@@ -540,7 +540,7 @@ int main(int argc, char *argv[])
 #ifdef __APPLE__
         else if (i == 5)
         {
-            QString appVersionPath = dataDir.filePath(QString::fromAscii("megasync.version"));
+            QString appVersionPath = dataDir.filePath(QString::fromLatin1("megasync.version"));
             QFile fappVersionPath(appVersionPath);
             if (!fappVersionPath.exists())
             {
@@ -556,7 +556,7 @@ int main(int argc, char *argv[])
         #endif
     }
 
-    QString appVersionPath = dataDir.filePath(QString::fromAscii("megasync.version"));
+    QString appVersionPath = dataDir.filePath(QString::fromLatin1("megasync.version"));
     QFile fappVersionPath(appVersionPath);
     if (fappVersionPath.open(QIODevice::WriteOnly))
     {
@@ -572,16 +572,16 @@ int main(int argc, char *argv[])
     Platform::initialize(argc, argv);
 
 #if !defined(__APPLE__) && !defined (_WIN32)
-    QFontDatabase::addApplicationFont(QString::fromAscii("://fonts/OpenSans-Regular.ttf"));
-    QFontDatabase::addApplicationFont(QString::fromAscii("://fonts/OpenSans-Semibold.ttf"));
+    QFontDatabase::addApplicationFont(QString::fromLatin1("://fonts/OpenSans-Regular.ttf"));
+    QFontDatabase::addApplicationFont(QString::fromLatin1("://fonts/OpenSans-Semibold.ttf"));
 
-    QFont font(QString::fromAscii("Open Sans"), 8);
+    QFont font(QString::fromLatin1("Open Sans"), 8);
     app.setFont(font);
 #endif
-    QFontDatabase::addApplicationFont(QString::fromAscii("://fonts/SourceSansPro-Light.ttf"));
-    QFontDatabase::addApplicationFont(QString::fromAscii("://fonts/SourceSansPro-Bold.ttf"));
-    QFontDatabase::addApplicationFont(QString::fromAscii("://fonts/SourceSansPro-Regular.ttf"));
-    QFontDatabase::addApplicationFont(QString::fromAscii("://fonts/SourceSansPro-Semibold.ttf"));
+    QFontDatabase::addApplicationFont(QString::fromLatin1("://fonts/SourceSansPro-Light.ttf"));
+    QFontDatabase::addApplicationFont(QString::fromLatin1("://fonts/SourceSansPro-Bold.ttf"));
+    QFontDatabase::addApplicationFont(QString::fromLatin1("://fonts/SourceSansPro-Regular.ttf"));
+    QFontDatabase::addApplicationFont(QString::fromLatin1("://fonts/SourceSansPro-Semibold.ttf"));
 
     app.initialize();
     app.start();
@@ -700,9 +700,9 @@ MegaApplication::MegaApplication(int &argc, char **argv) :
 #endif
 
     //Set QApplication fields
-    setOrganizationName(QString::fromAscii("Mega Limited"));
-    setOrganizationDomain(QString::fromAscii("mega.co.nz"));
-    setApplicationName(QString::fromAscii("MEGAsync"));
+    setOrganizationName(QString::fromLatin1("Mega Limited"));
+    setOrganizationDomain(QString::fromLatin1("mega.co.nz"));
+    setApplicationName(QString::fromLatin1("MEGAsync"));
     setApplicationVersion(QString::number(Preferences::VERSION_CODE));
 
 #ifdef _WIN32
@@ -746,7 +746,7 @@ MegaApplication::MegaApplication(int &argc, char **argv) :
     QDir currentDir(dataPath);
     if (!currentDir.exists())
     {
-        currentDir.mkpath(QString::fromAscii("."));
+        currentDir.mkpath(QString::fromLatin1("."));
     }
     QDir::setCurrent(dataPath);
 
@@ -805,13 +805,13 @@ MegaApplication::MegaApplication(int &argc, char **argv) :
     {
         int len = lstrlen(commonPath);
         if (!memcmp(commonPath, (WCHAR *)appDirPath.utf16(), len * sizeof(WCHAR))
-                && appDirPath.size() > len && appDirPath[len] == QChar::fromAscii('\\'))
+                && appDirPath.size() > len && appDirPath[len] == QChar::fromLatin1('\\'))
         {
             isPublic = true;
 
             int intVersion = 0;
             QDir dataDir(dataPath);
-            QString appVersionPath = dataDir.filePath(QString::fromAscii("megasync.version"));
+            QString appVersionPath = dataDir.filePath(QString::fromLatin1("megasync.version"));
             QFile f(appVersionPath);
             if (f.open(QFile::ReadOnly | QFile::Text))
             {
@@ -942,7 +942,7 @@ void MegaApplication::initialize()
     preferences->initialize(dataPath);
     if (preferences->error())
     {
-        QMegaMessageBox::critical(NULL, QString::fromAscii("MEGAsync"), tr("Your config is corrupt, please start over"), Utilities::getDevicePixelRatio());
+        QMegaMessageBox::critical(NULL, QString::fromLatin1("MEGAsync"), tr("Your config is corrupt, please start over"), Utilities::getDevicePixelRatio());
     }
 
     preferences->setLastStatsRequest(0);
@@ -965,7 +965,7 @@ void MegaApplication::initialize()
         toggleLogging();
     }
 
-    QString basePath = QDir::toNativeSeparators(dataPath + QString::fromAscii("/"));
+    QString basePath = QDir::toNativeSeparators(dataPath + QString::fromLatin1("/"));
 #ifndef __APPLE__
     megaApi = new MegaApi(Preferences::CLIENT_KEY, basePath.toUtf8().constData(), Preferences::USER_AGENT);
 #else
@@ -974,7 +974,7 @@ void MegaApplication::initialize()
 
     megaApiFolders = new MegaApi(Preferences::CLIENT_KEY, basePath.toUtf8().constData(), Preferences::USER_AGENT);
 
-    QString stagingPath = QDir(dataPath).filePath(QString::fromAscii("megasync.staging"));
+    QString stagingPath = QDir(dataPath).filePath(QString::fromLatin1("megasync.staging"));
     QFile fstagingPath(stagingPath);
     if (fstagingPath.exists())
     {
@@ -1060,9 +1060,9 @@ void MegaApplication::initialize()
         {
             di.next();
             const QFileInfo& fi = di.fileInfo();
-            if (!fi.fileName().contains(QString::fromUtf8("transfers_")) && (fi.fileName().endsWith(QString::fromAscii(".db"))
-                    || fi.fileName().endsWith(QString::fromAscii(".db-wal"))
-                    || fi.fileName().endsWith(QString::fromAscii(".db-shm"))))
+            if (!fi.fileName().contains(QString::fromUtf8("transfers_")) && (fi.fileName().endsWith(QString::fromLatin1(".db"))
+                    || fi.fileName().endsWith(QString::fromLatin1(".db-wal"))
+                    || fi.fileName().endsWith(QString::fromLatin1(".db-shm"))))
             {
                 QFile::remove(di.filePath());
             }
@@ -1071,13 +1071,13 @@ void MegaApplication::initialize()
         QStringList reports = CrashHandler::instance()->getPendingCrashReports();
         if (reports.size())
         {
-            CrashReportDialog crashDialog(reports.join(QString::fromAscii("------------------------------\n")));
+            CrashReportDialog crashDialog(reports.join(QString::fromLatin1("------------------------------\n")));
             if (crashDialog.exec() == QDialog::Accepted)
             {
                 applyProxySettings();
                 CrashHandler::instance()->sendPendingCrashReports(crashDialog.getUserMessage());
 #ifndef __APPLE__
-                QMegaMessageBox::information(NULL, QString::fromAscii("MEGAsync"), tr("Thank you for your collaboration!"), Utilities::getDevicePixelRatio());
+                QMegaMessageBox::information(NULL, QString::fromLatin1("MEGAsync"), tr("Thank you for your collaboration!"), Utilities::getDevicePixelRatio());
 #endif
             }
         }
@@ -1106,7 +1106,7 @@ void MegaApplication::initialize()
     QDir dataDir(dataPath);
     if (dataDir.exists())
     {
-        QString appShowInterfacePath = dataDir.filePath(QString::fromAscii("megasync.show"));
+        QString appShowInterfacePath = dataDir.filePath(QString::fromLatin1("megasync.show"));
         QFileSystemWatcher *watcher = new QFileSystemWatcher(this);
         QFile fappShowInterfacePath(appShowInterfacePath);
         if (fappShowInterfacePath.open(QIODevice::WriteOnly))
@@ -1165,7 +1165,7 @@ void MegaApplication::changeLanguage(QString languageCode)
 #ifdef Q_OS_LINUX
 void MegaApplication::setTrayIconFromTheme(QString icon)
 {
-    QString name = QString(icon).replace(QString::fromAscii("://images/"), QString::fromAscii("mega")).replace(QString::fromAscii(".svg"),QString::fromAscii(""));
+    QString name = QString(icon).replace(QString::fromLatin1("://images/"), QString::fromLatin1("mega")).replace(QString::fromLatin1(".svg"),QString::fromLatin1(""));
     trayIcon->setIcon(QIcon::fromTheme(name, QIcon(icon)));
 }
 #endif
@@ -1183,9 +1183,9 @@ void MegaApplication::updateTrayIcon()
     if (infoOverQuota)
     {
         tooltip = QCoreApplication::applicationName()
-                + QString::fromAscii(" ")
+                + QString::fromLatin1(" ")
                 + Preferences::VERSION_STRING
-                + QString::fromAscii("\n")
+                + QString::fromLatin1("\n")
                 + tr("Over quota");
 
 #ifndef __APPLE__
@@ -1208,9 +1208,9 @@ void MegaApplication::updateTrayIcon()
         if (!infoDialog)
         {
             tooltip = QCoreApplication::applicationName()
-                    + QString::fromAscii(" ")
+                    + QString::fromLatin1(" ")
                     + Preferences::VERSION_STRING
-                    + QString::fromAscii("\n")
+                    + QString::fromLatin1("\n")
                     + tr("Logging in");
 
     #ifndef __APPLE__
@@ -1232,9 +1232,9 @@ void MegaApplication::updateTrayIcon()
         else
         {
             tooltip = QCoreApplication::applicationName()
-                    + QString::fromAscii(" ")
+                    + QString::fromLatin1(" ")
                     + Preferences::VERSION_STRING
-                    + QString::fromAscii("\n")
+                    + QString::fromLatin1("\n")
                     + tr("You are not logged in");
 
     #ifndef __APPLE__
@@ -1256,9 +1256,9 @@ void MegaApplication::updateTrayIcon()
     else if (!megaApi->isFilesystemAvailable())
     {
         tooltip = QCoreApplication::applicationName()
-                + QString::fromAscii(" ")
+                + QString::fromLatin1(" ")
                 + Preferences::VERSION_STRING
-                + QString::fromAscii("\n")
+                + QString::fromLatin1("\n")
                 + tr("Fetching file list...");
 
 #ifndef __APPLE__
@@ -1280,9 +1280,9 @@ void MegaApplication::updateTrayIcon()
     else if (paused)
     {
         tooltip = QCoreApplication::applicationName()
-                + QString::fromAscii(" ")
+                + QString::fromLatin1(" ")
                 + Preferences::VERSION_STRING
-                + QString::fromAscii("\n")
+                + QString::fromLatin1("\n")
                 + tr("Paused");
 
 #ifndef __APPLE__
@@ -1307,25 +1307,25 @@ void MegaApplication::updateTrayIcon()
         if (indexing)
         {
             tooltip = QCoreApplication::applicationName()
-                    + QString::fromAscii(" ")
+                    + QString::fromLatin1(" ")
                     + Preferences::VERSION_STRING
-                    + QString::fromAscii("\n")
+                    + QString::fromLatin1("\n")
                     + tr("Scanning");
         }
         else if (waiting || (bwOverquotaTimestamp > QDateTime::currentMSecsSinceEpoch() / 1000))
         {
             tooltip = QCoreApplication::applicationName()
-                    + QString::fromAscii(" ")
+                    + QString::fromLatin1(" ")
                     + Preferences::VERSION_STRING
-                    + QString::fromAscii("\n")
+                    + QString::fromLatin1("\n")
                     + tr("Waiting");
         }
         else
         {
             tooltip = QCoreApplication::applicationName()
-                    + QString::fromAscii(" ")
+                    + QString::fromLatin1(" ")
                     + Preferences::VERSION_STRING
-                    + QString::fromAscii("\n")
+                    + QString::fromLatin1("\n")
                     + tr("Syncing");
         }
 
@@ -1348,9 +1348,9 @@ void MegaApplication::updateTrayIcon()
     else
     {
         tooltip = QCoreApplication::applicationName()
-                + QString::fromAscii(" ")
+                + QString::fromLatin1(" ")
                 + Preferences::VERSION_STRING
-                + QString::fromAscii("\n")
+                + QString::fromLatin1("\n")
                 + tr("Up to date");
 
 #ifndef __APPLE__
@@ -1377,9 +1377,9 @@ void MegaApplication::updateTrayIcon()
     {
         //Override the current state
         tooltip = QCoreApplication::applicationName()
-                + QString::fromAscii(" ")
+                + QString::fromLatin1(" ")
                 + Preferences::VERSION_STRING
-                + QString::fromAscii("\n")
+                + QString::fromLatin1("\n")
                 + tr("No Internet connection");
 
 #ifndef __APPLE__
@@ -1395,7 +1395,7 @@ void MegaApplication::updateTrayIcon()
 
     if (updateAvailable)
     {
-        tooltip += QString::fromAscii("\n")
+        tooltip += QString::fromLatin1("\n")
                 + tr("Update available!");
     }
 
@@ -1456,12 +1456,12 @@ void MegaApplication::start()
 
 #ifndef __APPLE__
     #ifdef _WIN32
-        trayIcon->setIcon(QIcon(QString::fromAscii("://images/tray_sync.ico")));
+        trayIcon->setIcon(QIcon(QString::fromLatin1("://images/tray_sync.ico")));
     #else
-        setTrayIconFromTheme(QString::fromAscii("://images/synching.svg"));
+        setTrayIconFromTheme(QString::fromLatin1("://images/synching.svg"));
     #endif
 #else
-    QIcon ic = QIcon(QString::fromAscii("://images/icon_syncing_mac.png"));
+    QIcon ic = QIcon(QString::fromLatin1("://images/icon_syncing_mac.png"));
     ic.setIsMask(true);
     trayIcon->setIcon(ic);
 
@@ -1471,7 +1471,7 @@ void MegaApplication::start()
         scanningTimer->start();
     }
 #endif
-    trayIcon->setToolTip(QCoreApplication::applicationName() + QString::fromAscii(" ") + Preferences::VERSION_STRING + QString::fromAscii("\n") + tr("Logging in"));
+    trayIcon->setToolTip(QCoreApplication::applicationName() + QString::fromLatin1(" ") + Preferences::VERSION_STRING + QString::fromLatin1("\n") + tr("Logging in"));
     trayIcon->show();
 
     if (!preferences->lastExecutionTime())
@@ -1814,7 +1814,7 @@ void MegaApplication::startSyncs()
             continue;
         }
 
-        MegaApi::log(MegaApi::LOG_LEVEL_INFO, QString::fromAscii("Sync  %1 added.").arg(i).toUtf8().constData());
+        MegaApi::log(MegaApi::LOG_LEVEL_INFO, QString::fromLatin1("Sync  %1 added.").arg(i).toUtf8().constData());
         megaApi->syncFolder(localFolder.toUtf8().constData(), node);
         delete node;
     }
@@ -1974,7 +1974,7 @@ void MegaApplication::processDownloadQueue(QString path)
     }
 
     QDir dir(path);
-    if (!dir.exists() && !dir.mkpath(QString::fromAscii(".")))
+    if (!dir.exists() && !dir.mkpath(QString::fromLatin1(".")))
     {
         QQueue<MegaNode *>::iterator it;
         for (it = downloadQueue.begin(); it != downloadQueue.end(); ++it)
@@ -2768,7 +2768,7 @@ void MegaApplication::cleanAll()
         appPath.cdUp();
         appPath.cdUp();
 
-        args.append(QString::fromAscii("-n"));
+        args.append(QString::fromLatin1("-n"));
         args.append(appPath.absolutePath());
         QProcess::startDetached(launchCommand, args);
 
@@ -3211,8 +3211,8 @@ void MegaApplication::scanningAnimationStep()
 
     scanningAnimationIndex = scanningAnimationIndex%4;
     scanningAnimationIndex++;
-    QIcon ic = QIcon(QString::fromAscii("://images/icon_syncing_mac") +
-                     QString::number(scanningAnimationIndex) + QString::fromAscii(".png"));
+    QIcon ic = QIcon(QString::fromLatin1("://images/icon_syncing_mac") +
+                     QString::number(scanningAnimationIndex) + QString::fromLatin1(".png"));
 #ifdef __APPLE__
     ic.setIsMask(true);
 #endif
@@ -3257,7 +3257,7 @@ void MegaApplication::runConnectivityCheck()
             string sProxyURL = autoProxy->getProxyURL();
             QString proxyURL = QString::fromUtf8(sProxyURL.data());
 
-            QStringList parts = proxyURL.split(QString::fromAscii("://"));
+            QStringList parts = proxyURL.split(QString::fromLatin1("://"));
             if (parts.size() == 2 && parts[0].startsWith(QString::fromUtf8("socks")))
             {
                 proxy.setType(QNetworkProxy::Socks5Proxy);
@@ -3267,7 +3267,7 @@ void MegaApplication::runConnectivityCheck()
                 proxy.setType(QNetworkProxy::HttpProxy);
             }
 
-            QStringList arguments = parts[parts.size()-1].split(QString::fromAscii(":"));
+            QStringList arguments = parts[parts.size()-1].split(QString::fromLatin1(":"));
             if (arguments.size() == 2)
             {
                 proxy.setHostName(arguments[0]);
@@ -3493,7 +3493,7 @@ void MegaApplication::cleanLocalCaches(bool all)
             QString syncPath = preferences->getLocalFolder(i);
             if (!syncPath.isEmpty())
             {
-                QDir cacheDir(syncPath + QDir::separator() + QString::fromAscii(MEGA_DEBRIS_FOLDER));
+                QDir cacheDir(syncPath + QDir::separator() + QString::fromLatin1(MEGA_DEBRIS_FOLDER));
                 if (cacheDir.exists())
                 {
                     QFileInfoList dailyCaches = cacheDir.entryInfoList(QDir::AllEntries | QDir::NoDotAndDotDot);
@@ -3783,7 +3783,7 @@ void MegaApplication::applyProxySettings()
             string sProxyURL = proxySettings->getProxyURL();
             QString proxyURL = QString::fromUtf8(sProxyURL.data());
 
-            QStringList arguments = proxyURL.split(QString::fromAscii(":"));
+            QStringList arguments = proxyURL.split(QString::fromLatin1(":"));
             if (arguments.size() == 2)
             {
                 proxy.setType(QNetworkProxy::HttpProxy);
@@ -3833,7 +3833,7 @@ void MegaApplication::handleLocalPath(const QUrl &url)
     else
     {
         #ifdef WIN32
-        if (path.startsWith(QString::fromAscii("\\\\?\\")))
+        if (path.startsWith(QString::fromLatin1("\\\\?\\")))
         {
             path = path.mid(4);
         }
@@ -4144,7 +4144,7 @@ void MegaApplication::showInFolder(int activationButton)
             && notification->getData().size() > 1)
     {
         QString localPath = QDir::toNativeSeparators(notification->getData().mid(1));
-        if (notification->getData().at(0) == QChar::fromAscii('1'))
+        if (notification->getData().at(0) == QChar::fromLatin1('1'))
         {
             Platform::showInFolder(localPath);
         }
@@ -4160,7 +4160,7 @@ void MegaApplication::openFolderPath(QString localPath)
     if (!localPath.isEmpty())
     {
         #ifdef WIN32
-        if (localPath.startsWith(QString::fromAscii("\\\\?\\")))
+        if (localPath.startsWith(QString::fromLatin1("\\\\?\\")))
         {
             localPath = localPath.mid(4);
         }
@@ -4765,7 +4765,7 @@ void MegaApplication::changeState()
 #ifdef _WIN32
 void MegaApplication::changeDisplay(QScreen *disp)
 {
-    MegaApi::log(MegaApi::LOG_LEVEL_DEBUG, QString::fromAscii("DISPLAY CHANGED").toUtf8().constData());
+    MegaApi::log(MegaApi::LOG_LEVEL_DEBUG, QString::fromLatin1("DISPLAY CHANGED").toUtf8().constData());
 
     if (infoDialog)
     {
@@ -4828,19 +4828,19 @@ void MegaApplication::createTrayIcon()
 #endif
 
     trayIcon->setToolTip(QCoreApplication::applicationName()
-                     + QString::fromAscii(" ")
+                     + QString::fromLatin1(" ")
                      + Preferences::VERSION_STRING
-                     + QString::fromAscii("\n")
+                     + QString::fromLatin1("\n")
                      + tr("Starting"));
 
 #ifndef __APPLE__
     #ifdef _WIN32
-        trayIcon->setIcon(QIcon(QString::fromAscii("://images/tray_sync.ico")));
+        trayIcon->setIcon(QIcon(QString::fromLatin1("://images/tray_sync.ico")));
     #else
-        setTrayIconFromTheme(QString::fromAscii("://images/synching.svg"));
+        setTrayIconFromTheme(QString::fromLatin1("://images/synching.svg"));
     #endif
 #else
-    QIcon ic = QIcon(QString::fromAscii("://images/icon_syncing_mac.png"));
+    QIcon ic = QIcon(QString::fromLatin1("://images/icon_syncing_mac.png"));
     ic.setIsMask(true);
     trayIcon->setIcon(ic);
 
@@ -5436,7 +5436,7 @@ void MegaApplication::onRequestLinksFinished()
         exportOps--;
         return;
     }
-    QString linkForClipboard(links.join(QChar::fromAscii('\n')));
+    QString linkForClipboard(links.join(QChar::fromLatin1('\n')));
     QApplication::clipboard()->setText(linkForClipboard);
     if (links.size() == 1)
     {
@@ -6098,9 +6098,9 @@ void MegaApplication::createTrayMenu()
     {
         trayMenu.reset(new QMenu());
 #ifdef __APPLE__
-        trayMenu->setStyleSheet(QString::fromAscii("QMenu {background: #ffffff; padding-top: 8px; padding-bottom: 8px;}"));
+        trayMenu->setStyleSheet(QString::fromLatin1("QMenu {background: #ffffff; padding-top: 8px; padding-bottom: 8px;}"));
 #else
-        trayMenu->setStyleSheet(QString::fromAscii("QMenu { border: 1px solid #B8B8B8; border-radius: 5px; background: #ffffff; padding-top: 5px; padding-bottom: 5px;}"));
+        trayMenu->setStyleSheet(QString::fromLatin1("QMenu { border: 1px solid #B8B8B8; border-radius: 5px; background: #ffffff; padding-top: 5px; padding-bottom: 5px;}"));
 #endif
 
         //Highlight menu entry on mouse over
@@ -6117,9 +6117,9 @@ void MegaApplication::createTrayMenu()
     }
 
 #ifndef __APPLE__
-    exitAction = new MenuItemAction(tr("Exit"), QIcon(QString::fromAscii("://images/ico_quit_out.png")), QIcon(QString::fromAscii("://images/ico_quit_over.png")), true);
+    exitAction = new MenuItemAction(tr("Exit"), QIcon(QString::fromLatin1("://images/ico_quit_out.png")), QIcon(QString::fromLatin1("://images/ico_quit_over.png")), true);
 #else
-    exitAction = new MenuItemAction(tr("Quit"), QIcon(QString::fromAscii("://images/ico_quit_out.png")), QIcon(QString::fromAscii("://images/ico_quit_over.png")), true);
+    exitAction = new MenuItemAction(tr("Quit"), QIcon(QString::fromLatin1("://images/ico_quit_out.png")), QIcon(QString::fromLatin1("://images/ico_quit_over.png")), true);
 #endif
     connect(exitAction, SIGNAL(triggered()), this, SLOT(exitApplication()), Qt::QueuedConnection);
 
@@ -6130,9 +6130,9 @@ void MegaApplication::createTrayMenu()
     }
 
 #ifndef __APPLE__
-    settingsAction = new MenuItemAction(tr("Settings"), QIcon(QString::fromAscii("://images/ico_preferences_out.png")), QIcon(QString::fromAscii("://images/ico_preferences_over.png")), true);
+    settingsAction = new MenuItemAction(tr("Settings"), QIcon(QString::fromLatin1("://images/ico_preferences_out.png")), QIcon(QString::fromLatin1("://images/ico_preferences_over.png")), true);
 #else
-    settingsAction = new MenuItemAction(tr("Preferences"), QIcon(QString::fromAscii("://images/ico_preferences_out.png")), QIcon(QString::fromAscii("://images/ico_preferences_over.png")), true);
+    settingsAction = new MenuItemAction(tr("Preferences"), QIcon(QString::fromLatin1("://images/ico_preferences_out.png")), QIcon(QString::fromLatin1("://images/ico_preferences_over.png")), true);
 #endif
     connect(settingsAction, SIGNAL(triggered()), this, SLOT(openSettings()), Qt::QueuedConnection);
 
@@ -6142,7 +6142,7 @@ void MegaApplication::createTrayMenu()
         webAction = NULL;
     }
 
-    webAction = new MenuItemAction(tr("MEGA website"), QIcon(QString::fromAscii("://images/ico_MEGA_website_out.png")), QIcon(QString::fromAscii("://images/ico_MEGA_website_over.png")), true);
+    webAction = new MenuItemAction(tr("MEGA website"), QIcon(QString::fromLatin1("://images/ico_MEGA_website_out.png")), QIcon(QString::fromLatin1("://images/ico_MEGA_website_over.png")), true);
     connect(webAction, SIGNAL(triggered()), this, SLOT(officialWeb()), Qt::QueuedConnection);
 
     if (addSyncAction)
@@ -6154,12 +6154,12 @@ void MegaApplication::createTrayMenu()
     int num = (megaApi && preferences->logged()) ? preferences->getNumSyncedFolders() : 0;
     if (num == 0)
     {
-        addSyncAction = new MenuItemAction(tr("Add Sync"), QIcon(QString::fromAscii("://images/ico_syncs_out.png")), QIcon(QString::fromAscii("://images/ico_syncs_over.png")), true);
+        addSyncAction = new MenuItemAction(tr("Add Sync"), QIcon(QString::fromLatin1("://images/ico_syncs_out.png")), QIcon(QString::fromLatin1("://images/ico_syncs_over.png")), true);
         connect(addSyncAction, SIGNAL(triggered()), infoDialog, SLOT(addSync()),Qt::QueuedConnection);
     }
     else
     {
-        addSyncAction = new MenuItemAction(tr("Syncs"), QIcon(QString::fromAscii("://images/ico_syncs_out.png")), QIcon(QString::fromAscii("://images/ico_syncs_over.png")), true);
+        addSyncAction = new MenuItemAction(tr("Syncs"), QIcon(QString::fromLatin1("://images/ico_syncs_out.png")), QIcon(QString::fromLatin1("://images/ico_syncs_over.png")), true);
         if (syncsMenu)
         {
             for (QAction *a: syncsMenu->actions())
@@ -6174,9 +6174,9 @@ void MegaApplication::createTrayMenu()
         syncsMenu.reset(new QMenu());
 
 #ifdef __APPLE__
-        syncsMenu->setStyleSheet(QString::fromAscii("QMenu {background: #ffffff; padding-top: 8px; padding-bottom: 8px;}"));
+        syncsMenu->setStyleSheet(QString::fromLatin1("QMenu {background: #ffffff; padding-top: 8px; padding-bottom: 8px;}"));
 #else
-        syncsMenu->setStyleSheet(QString::fromAscii("QMenu { border: 1px solid #B8B8B8; border-radius: 5px; background: #ffffff; padding-top: 8px; padding-bottom: 8px;}"));
+        syncsMenu->setStyleSheet(QString::fromLatin1("QMenu { border: 1px solid #B8B8B8; border-radius: 5px; background: #ffffff; padding-top: 8px; padding-bottom: 8px;}"));
 #endif
 
 
@@ -6198,8 +6198,8 @@ void MegaApplication::createTrayMenu()
             }
 
             activeFolders++;
-            MenuItemAction *action = new MenuItemAction(preferences->getSyncName(i), QIcon(QString::fromAscii("://images/ico_drop_synched_folder.png")),
-                                                        QIcon(QString::fromAscii("://images/ico_drop_synched_folder_over.png")), true);
+            MenuItemAction *action = new MenuItemAction(preferences->getSyncName(i), QIcon(QString::fromLatin1("://images/ico_drop_synched_folder.png")),
+                                                        QIcon(QString::fromLatin1("://images/ico_drop_synched_folder_over.png")), true);
             connect(action, SIGNAL(triggered()), menuSignalMapper, SLOT(map()), Qt::QueuedConnection);
 
             syncsMenu->addAction(action);
@@ -6225,8 +6225,8 @@ void MegaApplication::createTrayMenu()
                 long long rootHandle = rootNode->getHandle();
                 if ((num > 1) || (firstSyncHandle != rootHandle))
                 {
-                    MenuItemAction *addAction = new MenuItemAction(tr("Add Sync"), QIcon(QString::fromAscii("://images/ico_add_sync.png")),
-                                                                       QIcon(QString::fromAscii("://images/ico_drop_add_sync_over.png")), true);
+                    MenuItemAction *addAction = new MenuItemAction(tr("Add Sync"), QIcon(QString::fromLatin1("://images/ico_add_sync.png")),
+                                                                       QIcon(QString::fromLatin1("://images/ico_drop_add_sync_over.png")), true);
                     connect(addAction, SIGNAL(triggered()), infoDialog, SLOT(addSync()), Qt::QueuedConnection);
 
                     if (activeFolders)
@@ -6248,7 +6248,7 @@ void MegaApplication::createTrayMenu()
         importLinksAction = NULL;
     }
 
-    importLinksAction = new MenuItemAction(tr("Import links"), QIcon(QString::fromAscii("://images/ico_Import_links_out.png")), QIcon(QString::fromAscii("://images/ico_Import_links_over.png")), true);
+    importLinksAction = new MenuItemAction(tr("Import links"), QIcon(QString::fromLatin1("://images/ico_Import_links_out.png")), QIcon(QString::fromLatin1("://images/ico_Import_links_over.png")), true);
     connect(importLinksAction, SIGNAL(triggered()), this, SLOT(importLinks()), Qt::QueuedConnection);
 
     if (uploadAction)
@@ -6257,7 +6257,7 @@ void MegaApplication::createTrayMenu()
         uploadAction = NULL;
     }
 
-    uploadAction = new MenuItemAction(tr("Upload"), QIcon(QString::fromAscii("://images/ico_upload_out.png")), QIcon(QString::fromAscii("://images/ico_upload_over.png")), true);
+    uploadAction = new MenuItemAction(tr("Upload"), QIcon(QString::fromLatin1("://images/ico_upload_out.png")), QIcon(QString::fromLatin1("://images/ico_upload_over.png")), true);
     connect(uploadAction, SIGNAL(triggered()), this, SLOT(uploadActionClicked()), Qt::QueuedConnection);
 
     if (downloadAction)
@@ -6266,7 +6266,7 @@ void MegaApplication::createTrayMenu()
         downloadAction = NULL;
     }
 
-    downloadAction = new MenuItemAction(tr("Download"), QIcon(QString::fromAscii("://images/ico_download_out.png")), QIcon(QString::fromAscii("://images/ico_download_over.png")), true);
+    downloadAction = new MenuItemAction(tr("Download"), QIcon(QString::fromLatin1("://images/ico_download_out.png")), QIcon(QString::fromLatin1("://images/ico_download_over.png")), true);
     connect(downloadAction, SIGNAL(triggered()), this, SLOT(downloadActionClicked()), Qt::QueuedConnection);
 
     if (streamAction)
@@ -6275,7 +6275,7 @@ void MegaApplication::createTrayMenu()
         streamAction = NULL;
     }
 
-    streamAction = new MenuItemAction(tr("Stream"), QIcon(QString::fromAscii("://images/ico_stream_out.png")), QIcon(QString::fromAscii("://images/ico_stream_over.png")), true);
+    streamAction = new MenuItemAction(tr("Stream"), QIcon(QString::fromLatin1("://images/ico_stream_out.png")), QIcon(QString::fromLatin1("://images/ico_stream_over.png")), true);
     connect(streamAction, SIGNAL(triggered()), this, SLOT(streamActionClicked()), Qt::QueuedConnection);
 
     if (updateAction)
@@ -6286,11 +6286,11 @@ void MegaApplication::createTrayMenu()
 
     if (updateAvailable)
     {
-        updateAction = new MenuItemAction(tr("Install update"), QIcon(QString::fromAscii("://images/ico_about_MEGA_out.png")), QIcon(QString::fromAscii("://images/ico_about_MEGA_over.png")), true);
+        updateAction = new MenuItemAction(tr("Install update"), QIcon(QString::fromLatin1("://images/ico_about_MEGA_out.png")), QIcon(QString::fromLatin1("://images/ico_about_MEGA_over.png")), true);
     }
     else
     {
-        updateAction = new MenuItemAction(tr("About MEGAsync"), QIcon(QString::fromAscii("://images/ico_about_MEGA_out.png")), QIcon(QString::fromAscii("://images/ico_about_MEGA_over.png")), true);
+        updateAction = new MenuItemAction(tr("About MEGAsync"), QIcon(QString::fromLatin1("://images/ico_about_MEGA_out.png")), QIcon(QString::fromLatin1("://images/ico_about_MEGA_over.png")), true);
     }
     connect(updateAction, SIGNAL(triggered()), this, SLOT(onInstallUpdateClicked()), Qt::QueuedConnection);
 
@@ -6329,9 +6329,9 @@ void MegaApplication::createGuestMenu()
         trayGuestMenu.reset(new QMenu());
 
 #ifdef __APPLE__
-        trayGuestMenu->setStyleSheet(QString::fromAscii("QMenu {background: #ffffff; padding-top: 8px; padding-bottom: 8px;}"));
+        trayGuestMenu->setStyleSheet(QString::fromLatin1("QMenu {background: #ffffff; padding-top: 8px; padding-bottom: 8px;}"));
 #else
-        trayGuestMenu->setStyleSheet(QString::fromAscii("QMenu { border: 1px solid #B8B8B8; border-radius: 5px; background: #ffffff; padding-top: 5px; padding-bottom: 5px;}"));
+        trayGuestMenu->setStyleSheet(QString::fromLatin1("QMenu { border: 1px solid #B8B8B8; border-radius: 5px; background: #ffffff; padding-top: 5px; padding-bottom: 5px;}"));
 #endif
     }
 
@@ -6342,9 +6342,9 @@ void MegaApplication::createGuestMenu()
     }
 
 #ifndef __APPLE__
-    exitActionGuest = new MenuItemAction(tr("Exit"), QIcon(QString::fromAscii("://images/ico_quit_out.png")), QIcon(QString::fromAscii("://images/ico_quit_over.png")));
+    exitActionGuest = new MenuItemAction(tr("Exit"), QIcon(QString::fromLatin1("://images/ico_quit_out.png")), QIcon(QString::fromLatin1("://images/ico_quit_over.png")));
 #else
-    exitActionGuest = new MenuItemAction(tr("Quit"), QIcon(QString::fromAscii("://images/ico_quit_out.png")), QIcon(QString::fromAscii("://images/ico_quit_over.png")));
+    exitActionGuest = new MenuItemAction(tr("Quit"), QIcon(QString::fromLatin1("://images/ico_quit_out.png")), QIcon(QString::fromLatin1("://images/ico_quit_over.png")));
 #endif
     connect(exitActionGuest, SIGNAL(triggered()), this, SLOT(exitApplication()));
 
@@ -6356,11 +6356,11 @@ void MegaApplication::createGuestMenu()
 
     if (updateAvailable)
     {
-        updateActionGuest = new MenuItemAction(tr("Install update"), QIcon(QString::fromAscii("://images/ico_about_MEGA_out.png")), QIcon(QString::fromAscii("://images/ico_about_MEGA_over.png")));
+        updateActionGuest = new MenuItemAction(tr("Install update"), QIcon(QString::fromLatin1("://images/ico_about_MEGA_out.png")), QIcon(QString::fromLatin1("://images/ico_about_MEGA_over.png")));
     }
     else
     {
-        updateActionGuest = new MenuItemAction(tr("About MEGAsync"), QIcon(QString::fromAscii("://images/ico_about_MEGA_out.png")), QIcon(QString::fromAscii("://images/ico_about_MEGA_over.png")));
+        updateActionGuest = new MenuItemAction(tr("About MEGAsync"), QIcon(QString::fromLatin1("://images/ico_about_MEGA_out.png")), QIcon(QString::fromLatin1("://images/ico_about_MEGA_over.png")));
     }
     connect(updateActionGuest, SIGNAL(triggered()), this, SLOT(onInstallUpdateClicked()));
 
@@ -6371,9 +6371,9 @@ void MegaApplication::createGuestMenu()
     }
 
 #ifndef __APPLE__
-    settingsActionGuest = new MenuItemAction(tr("Settings"), QIcon(QString::fromAscii("://images/ico_preferences_out.png")), QIcon(QString::fromAscii("://images/ico_preferences_over.png")));
+    settingsActionGuest = new MenuItemAction(tr("Settings"), QIcon(QString::fromLatin1("://images/ico_preferences_out.png")), QIcon(QString::fromLatin1("://images/ico_preferences_over.png")));
 #else
-    settingsActionGuest = new MenuItemAction(tr("Preferences"), QIcon(QString::fromAscii("://images/ico_preferences_out.png")), QIcon(QString::fromAscii("://images/ico_preferences_over.png")));
+    settingsActionGuest = new MenuItemAction(tr("Preferences"), QIcon(QString::fromLatin1("://images/ico_preferences_out.png")), QIcon(QString::fromLatin1("://images/ico_preferences_over.png")));
 #endif
     connect(settingsActionGuest, SIGNAL(triggered()), this, SLOT(changeProxy()));
 
@@ -6646,7 +6646,7 @@ void MegaApplication::onRequestFinish(MegaApi*, MegaRequest *request, MegaError*
             {
                 if (!sslKeyPinningError)
                 {
-                    sslKeyPinningError = new QMessageBox(QMessageBox::Critical, QString::fromAscii("MEGAsync"),
+                    sslKeyPinningError = new QMessageBox(QMessageBox::Critical, QString::fromLatin1("MEGAsync"),
                                                 tr("MEGA is unable to connect securely through SSL. You might be on public WiFi with additional requirements.")
                                                 + QString::fromUtf8(" (Issuer: %1)").arg(QString::fromUtf8(request->getText() ? request->getText() : "Unknown")),
                                                          QMessageBox::Retry | QMessageBox::Yes | QMessageBox::Cancel);
@@ -6709,17 +6709,17 @@ void MegaApplication::onRequestFinish(MegaApi*, MegaRequest *request, MegaError*
 
             if (errorCode == MegaError::API_ESID)
             {
-                QMegaMessageBox::information(NULL, QString::fromAscii("MEGAsync"), tr("You have been logged out on this computer from another location"), Utilities::getDevicePixelRatio());
+                QMegaMessageBox::information(NULL, QString::fromLatin1("MEGAsync"), tr("You have been logged out on this computer from another location"), Utilities::getDevicePixelRatio());
             }
             else if (errorCode == MegaError::API_ESSL)
             {
-                QMegaMessageBox::critical(NULL, QString::fromAscii("MEGAsync"),
+                QMegaMessageBox::critical(NULL, QString::fromLatin1("MEGAsync"),
                                       tr("Our SSL key can't be verified. You could be affected by a man-in-the-middle attack or your antivirus software could be intercepting your communications and causing this problem. Please disable it and try again.")
                                        + QString::fromUtf8(" (Issuer: %1)").arg(QString::fromUtf8(request->getText() ? request->getText() : "Unknown")), Utilities::getDevicePixelRatio());
             }
             else if (errorCode != MegaError::API_EACCESS)
             {
-                QMegaMessageBox::information(NULL, QString::fromAscii("MEGAsync"), tr("You have been logged out because of this error: %1")
+                QMegaMessageBox::information(NULL, QString::fromLatin1("MEGAsync"), tr("You have been logged out because of this error: %1")
                                          .arg(QCoreApplication::translate("MegaError", e->getErrorString())), Utilities::getDevicePixelRatio());
             }
             unlink();
@@ -7134,7 +7134,7 @@ void MegaApplication::onRequestFinish(MegaApi*, MegaRequest *request, MegaError*
 
 #ifdef _WIN32
                     QString debrisPath = QDir::toNativeSeparators(preferences->getLocalFolder(i) +
-                            QDir::separator() + QString::fromAscii(MEGA_DEBRIS_FOLDER));
+                            QDir::separator() + QString::fromLatin1(MEGA_DEBRIS_FOLDER));
 
                     WIN32_FILE_ATTRIBUTE_DATA fad;
                     if (GetFileAttributesExW((LPCWSTR)debrisPath.utf16(),
@@ -7181,7 +7181,7 @@ void MegaApplication::onRequestFinish(MegaApi*, MegaRequest *request, MegaError*
             QString syncPath = QString::fromUtf8(request->getFile());
 
             #ifdef WIN32
-            if (syncPath.startsWith(QString::fromAscii("\\\\?\\")))
+            if (syncPath.startsWith(QString::fromLatin1("\\\\?\\")))
             {
                 syncPath = syncPath.mid(4);
             }
@@ -7449,7 +7449,7 @@ void MegaApplication::onTransferFinish(MegaApi* , MegaTransfer *transfer, MegaEr
         }
 
 #ifdef WIN32
-        if (localPath.startsWith(QString::fromAscii("\\\\?\\")))
+        if (localPath.startsWith(QString::fromLatin1("\\\\?\\")))
         {
             localPath = localPath.mid(4);
         }

--- a/src/MEGASync/control/CrashHandler.cpp
+++ b/src/MEGASync/control/CrashHandler.cpp
@@ -417,7 +417,7 @@ void CrashHandler::tryReboot()
         appPath.cdUp();
         appPath.cdUp();
 
-        args.append(QString::fromAscii("-n"));
+        args.append(QString::fromLatin1("-n"));
         args.append(appPath.absolutePath());
         QProcess::startDetached(launchCommand, args);
 #endif
@@ -475,7 +475,7 @@ QStringList CrashHandler::getPendingCrashReports()
     for (int i = 0; i < fiList.size(); i++)
     {
         QFile file(fiList[i].absoluteFilePath());
-        if (!file.fileName().endsWith(QString::fromAscii(".dmp")))
+        if (!file.fileName().endsWith(QString::fromLatin1(".dmp")))
         {
             continue;
         }
@@ -493,18 +493,18 @@ QStringList CrashHandler::getPendingCrashReports()
         QString crashReport = QString::fromUtf8(file.readAll());
         file.close();
 
-        QStringList lines = crashReport.split(QString::fromAscii("\n"));
+        QStringList lines = crashReport.split(QString::fromLatin1("\n"));
         if ((lines.size()<3)
-                || (lines.at(0) != QString::fromAscii("MEGAprivate ERROR DUMP"))
-                || (!lines.at(1).startsWith(QString::fromAscii("Application: ") + QApplication::applicationName()))
-                || (!lines.at(2).startsWith(QString::fromAscii("Version code: ") + QString::number(Preferences::VERSION_CODE))))
+                || (lines.at(0) != QString::fromLatin1("MEGAprivate ERROR DUMP"))
+                || (!lines.at(1).startsWith(QString::fromLatin1("Application: ") + QApplication::applicationName()))
+                || (!lines.at(2).startsWith(QString::fromLatin1("Version code: ") + QString::number(Preferences::VERSION_CODE))))
         {
             MegaApi::log(MegaApi::LOG_LEVEL_WARNING, QString::fromUtf8("Invalid or outdated dump file: %1").arg(file.fileName()).toUtf8().constData());
             file.remove();
             continue;
         }
 
-        QString crashHash = QString::fromAscii(QCryptographicHash::hash(crashReport.toUtf8(),QCryptographicHash::Md5).toHex());
+        QString crashHash = QString::fromLatin1(QCryptographicHash::hash(crashReport.toUtf8(),QCryptographicHash::Md5).toHex());
         if (!previousCrashes.contains(crashHash))
         {
             MegaApi::log(MegaApi::LOG_LEVEL_INFO, QString::fromUtf8("New crash file: %1  Hash: %2")
@@ -535,14 +535,14 @@ void CrashHandler::sendPendingCrashReports(QString userMessage)
     }
 
     crashes.append(userMessage);
-    QString postString = crashes.join(QString::fromAscii("------------------------------\n"));
-    postString.append(QString::fromAscii("\n------------------------------\n"));
+    QString postString = crashes.join(QString::fromLatin1("------------------------------\n"));
+    postString.append(QString::fromLatin1("\n------------------------------\n"));
 
     networkManager = new QNetworkAccessManager();
     connect(networkManager, SIGNAL(finished(QNetworkReply*)),
             this, SLOT(onPostFinished(QNetworkReply*)), Qt::UniqueConnection);
     request.setUrl(Preferences::CRASH_REPORT_URL);
-    request.setHeader(QNetworkRequest::ContentTypeHeader, QString::fromAscii("application/x-www-form-urlencoded"));
+    request.setHeader(QNetworkRequest::ContentTypeHeader, QString::fromLatin1("application/x-www-form-urlencoded"));
 
     MegaApi::log(MegaApi::LOG_LEVEL_INFO, "Sending crash reports");
     networkManager->post(request, postString.toUtf8());
@@ -556,7 +556,7 @@ void CrashHandler::discardPendingCrashReports()
     QStringList previousCrashes = preferences->getPreviousCrashes();
     for (int i = 0; i < crashes.size(); i++)
     {
-        QString crashHash = QString::fromAscii(QCryptographicHash::hash(crashes[i].toUtf8(),QCryptographicHash::Md5).toHex());
+        QString crashHash = QString::fromLatin1(QCryptographicHash::hash(crashes[i].toUtf8(),QCryptographicHash::Md5).toHex());
         if (!previousCrashes.contains(crashHash))
         {
             previousCrashes.append(crashHash);
@@ -607,7 +607,7 @@ void CrashHandler::deletePendingCrashReports()
     for (int i = 0; i < fiList.size(); i++)
     {
         QFileInfo fi = fiList[i];
-        if (fi.fileName().endsWith(QString::fromAscii(".dmp")))
+        if (fi.fileName().endsWith(QString::fromLatin1(".dmp")))
         {
             QFile::remove(fi.absoluteFilePath());
         }

--- a/src/MEGASync/control/EncryptedSettings.cpp
+++ b/src/MEGASync/control/EncryptedSettings.cpp
@@ -55,7 +55,7 @@ void EncryptedSettings::remove(const QString &key)
 {
     if (!key.length())
     {
-        QSettings::remove(QString::fromAscii(""));
+        QSettings::remove(QString::fromLatin1(""));
     }
     else
     {
@@ -110,7 +110,7 @@ QString EncryptedSettings::encrypt(const QString key, const QString value) const
     QByteArray xValue = XOR(k, value.toUtf8());
     QByteArray xKey = XOR(k, group().toAscii());
     QByteArray xEncrypted = XOR(k, Platform::encrypt(xValue, xKey));
-    return QString::fromAscii(xEncrypted.toBase64());
+    return QString::fromLatin1(xEncrypted.toBase64());
 }
 
 QString EncryptedSettings::decrypt(const QString key, const QString value) const
@@ -132,5 +132,5 @@ QString EncryptedSettings::hash(const QString key) const
     QByteArray xPath = XOR(encryptionKey, (key+group()).toUtf8());
     QByteArray keyHash = QCryptographicHash::hash(xPath, QCryptographicHash::Sha1);
     QByteArray xKeyHash = XOR(key.toUtf8(), keyHash);
-    return QString::fromAscii(xKeyHash.toHex());
+    return QString::fromLatin1(xKeyHash.toHex());
 }

--- a/src/MEGASync/control/ExportProcessor.cpp
+++ b/src/MEGASync/control/ExportProcessor.cpp
@@ -51,9 +51,9 @@ void ExportProcessor::requestLinks()
         if (mode == MODE_PATHS)
         {
     #ifdef WIN32
-            if (!fileList[i].startsWith(QString::fromAscii("\\\\")))
+            if (!fileList[i].startsWith(QString::fromLatin1("\\\\")))
             {
-                fileList[i].insert(0, QString::fromAscii("\\\\?\\"));
+                fileList[i].insert(0, QString::fromLatin1("\\\\?\\"));
             }
 
             string tmpPath((const char*)fileList[i].utf16(), fileList[i].size()*sizeof(wchar_t));
@@ -94,8 +94,8 @@ void ExportProcessor::onRequestFinish(MegaApi *, MegaRequest *request, MegaError
     }
     else
     {
-        publicLinks.append(QString::fromAscii(request->getLink()));
-        validPublicLinks.append(QString::fromAscii(request->getLink()));
+        publicLinks.append(QString::fromLatin1(request->getLink()));
+        validPublicLinks.append(QString::fromLatin1(request->getLink()));
         importSuccess++;
     }
 

--- a/src/MEGASync/control/HTTPServer.cpp
+++ b/src/MEGASync/control/HTTPServer.cpp
@@ -202,7 +202,7 @@ void HTTPServer::onTransferDataUpdate(MegaHandle handle, int state, long long pr
     if (tData->tPath.isEmpty() && !localPath.isEmpty())
     {
         #ifdef WIN32
-        if (localPath.startsWith(QString::fromAscii("\\\\?\\")))
+        if (localPath.startsWith(QString::fromLatin1("\\\\?\\")))
         {
             localPath = localPath.mid(4);
         }
@@ -235,7 +235,7 @@ void HTTPServer::readClient()
     {
         QStringList tokens = request->data.split(QString::fromUtf8("\r\n\r\n"));
         QStringList headers = tokens[0].split(QString::fromUtf8("\r\n"));
-        if (!headers.size() || !headers[0].startsWith(QString::fromAscii("POST")))
+        if (!headers.size() || !headers[0].startsWith(QString::fromLatin1("POST")))
         {
             MegaApi::log(MegaApi::LOG_LEVEL_WARNING, "Method not allowed for webclient request");
             rejectRequest(socket, QString::fromUtf8("405 Method Not Allowed"));
@@ -460,9 +460,9 @@ void HTTPServer::processRequest(QAbstractSocket *socket, HTTPRequest request)
                 int end;
                 bool firstnode = true;
 
-                while (request.data[start] == QChar::fromAscii('{'))
+                while (request.data[start] == QChar::fromLatin1('{'))
                 {
-                    end = request.data.indexOf(QChar::fromAscii('}'), start);
+                    end = request.data.indexOf(QChar::fromLatin1('}'), start);
                     if (end < 0)
                     {
                         MegaApi::log(MegaApi::LOG_LEVEL_ERROR, "Error parsing webclient request");

--- a/src/MEGASync/control/LinkProcessor.cpp
+++ b/src/MEGASync/control/LinkProcessor.cpp
@@ -137,9 +137,9 @@ void LinkProcessor::onRequestFinish(MegaApi *api, MegaRequest *request, MegaErro
         if (e->getErrorCode() == MegaError::API_OK)
         {
             MegaNode *rootNode = NULL;
-            if (linkList[currentIndex].count(QChar::fromAscii('!')) == 3)
+            if (linkList[currentIndex].count(QChar::fromLatin1('!')) == 3)
             {
-                QStringList linkparts = linkList[currentIndex].split(QChar::fromAscii('!'), QString::KeepEmptyParts);
+                QStringList linkparts = linkList[currentIndex].split(QChar::fromLatin1('!'), QString::KeepEmptyParts);
                 MegaHandle handle = MegaApi::base64ToHandle(linkparts.last().toUtf8().constData());
                 rootNode = megaApiFolders->getNodeByHandle(handle);
             }

--- a/src/MEGASync/control/MegaDownloader.cpp
+++ b/src/MEGASync/control/MegaDownloader.cpp
@@ -24,7 +24,7 @@ void MegaDownloader::download(MegaNode *parent, QString path, QString appData)
 bool MegaDownloader::processDownloadQueue(QQueue<MegaNode *> *downloadQueue, QString path, unsigned long long appDataId)
 {
     QDir dir(path);
-    if (!dir.exists() && !dir.mkpath(QString::fromAscii(".")))
+    if (!dir.exists() && !dir.mkpath(QString::fromLatin1(".")))
     {
         qDeleteAll(*downloadQueue);
         downloadQueue->clear();
@@ -113,7 +113,7 @@ void MegaDownloader::download(MegaNode *parent, QFileInfo info, QString appData)
     #ifndef WIN32
                 if (!megaApi->createLocalFolder(dir.toNativeSeparators(destPath).toUtf8().constData()))
     #else
-                if (!dir.mkpath(QString::fromAscii(".")))
+                if (!dir.mkpath(QString::fromLatin1(".")))
     #endif
                 {
                     return;

--- a/src/MEGASync/control/MegaSyncLogger.cpp
+++ b/src/MEGASync/control/MegaSyncLogger.cpp
@@ -136,7 +136,7 @@ void MegaSyncLogger::log(const char *time, int loglevel, const char *source, con
                     dataPath = Utilities::getDefaultBasePath();
                 }
 #endif
-                filePath = dataPath + QDir::separator() + QString::fromAscii("MEGAsync.log");
+                filePath = dataPath + QDir::separator() + QString::fromLatin1("MEGAsync.log");
             }
 
             QFile file(filePath);

--- a/src/MEGASync/control/MegaUploader.cpp
+++ b/src/MEGASync/control/MegaUploader.cpp
@@ -56,7 +56,7 @@ void MegaUploader::upload(QFileInfo info, MegaNode *parent, unsigned long long a
     string localPath = megaApi->getLocalPath(parent);
 #ifdef WIN32
         QString destPath = QDir::toNativeSeparators(QString::fromWCharArray((const wchar_t *)localPath.data()) + QDir::separator() + fileName);
-        if (destPath.startsWith(QString::fromAscii("\\\\?\\")))
+        if (destPath.startsWith(QString::fromLatin1("\\\\?\\")))
         {
             destPath = destPath.mid(4);
         }

--- a/src/MEGASync/control/Preferences.cpp
+++ b/src/MEGASync/control/Preferences.cpp
@@ -15,8 +15,8 @@ const char Preferences::USER_AGENT[] = "MEGAsync/4.2.5.0";
 const int Preferences::VERSION_CODE = 4205;
 const int Preferences::BUILD_ID = 0;
 // Do not change the location of VERSION_STRING, create_tarball.sh parses this file
-const QString Preferences::VERSION_STRING = QString::fromAscii("4.2.5");
-QString Preferences::SDK_ID = QString::fromAscii("fcd2f0e");
+const QString Preferences::VERSION_STRING = QString::fromLatin1("4.2.5");
+QString Preferences::SDK_ID = QString::fromLatin1("fcd2f0e");
 const QString Preferences::CHANGELOG = QString::fromUtf8(QT_TR_NOOP(
     "- Fix sync issues on macOS 10.15\n"
     "- Fix transfer resumption issues for webclient and public links downloads\n"
@@ -25,8 +25,8 @@ const QString Preferences::CHANGELOG = QString::fromUtf8(QT_TR_NOOP(
     "- Include option to add synchronizations from the main dialog\n"
     "- Other minor bug fixes and improvements"));
 
-const QString Preferences::TRANSLATION_FOLDER = QString::fromAscii("://translations/");
-const QString Preferences::TRANSLATION_PREFIX = QString::fromAscii("MEGASyncStrings_");
+const QString Preferences::TRANSLATION_FOLDER = QString::fromLatin1("://translations/");
+const QString Preferences::TRANSLATION_PREFIX = QString::fromLatin1("MEGASyncStrings_");
 
 int Preferences::STATE_REFRESH_INTERVAL_MS        = 10000;
 int Preferences::FINISHED_TRANSFER_REFRESH_INTERVAL_MS        = 10000;
@@ -203,7 +203,7 @@ const QString Preferences::FINDER_EXT_BUNDLE_ID = QString::fromUtf8("mega.mac.ME
 QStringList Preferences::HTTPS_ALLOWED_ORIGINS;
 bool Preferences::HTTPS_ORIGIN_CHECK_ENABLED = true;
 
-QString Preferences::BASE_URL = QString::fromAscii("https://mega.nz");
+QString Preferences::BASE_URL = QString::fromLatin1("https://mega.nz");
 
 #ifdef WIN32
     const QString Preferences::UPDATE_CHECK_URL                 = QString::fromUtf8("http://g.static.mega.co.nz/upd/wsync/v.txt");
@@ -213,136 +213,136 @@ QString Preferences::BASE_URL = QString::fromAscii("https://mega.nz");
 
 const char Preferences::UPDATE_PUBLIC_KEY[] = "EACTzXPE8fdMhm6LizLe1FxV2DncybVh2cXpW3momTb8tpzRNT833r1RfySz5uHe8gdoXN1W0eM5Bk8X-LefygYYDS9RyXrRZ8qXrr9ITJ4r8ATnFIEThO5vqaCpGWTVi5pOPI5FUTJuhghVKTyAels2SpYT5CmfSQIkMKv7YVldaV7A-kY060GfrNg4--ETyIzhvaSZ_jyw-gmzYl_dwfT9kSzrrWy1vQG8JPNjKVPC4MCTZJx9SNvp1fVi77hhgT-Mc5PLcDIfjustlJkDBHtmGEjyaDnaWQf49rGq94q23mLc56MSjKpjOR1TtpsCY31d1Oy2fEXFgghM0R-1UkKswVuWhEEd8nO2PimJOl4u9ZJ2PWtJL1Ro0Hlw9OemJ12klIAxtGV-61Z60XoErbqThwWT5Uu3D2gjK9e6rL9dufSoqjC7UA2C0h7KNtfUcUHw0UWzahlR8XBNFXaLWx9Z8fRtA_a4seZcr0AhIA7JdQG5i8tOZo966KcFnkU77pfQTSprnJhCfEmYbWm9EZA122LJBWq2UrSQQN3pKc9goNaaNxy5PYU1yXyiAfMVsBDmDonhRWQh2XhdV-FWJ3rOGMe25zOwV4z1XkNBuW4T1JF2FgqGR6_q74B2ccFC8vrNGvlTEcs3MSxTI_EKLXQvBYy7hxG8EPUkrMVCaWzzTQAFEQ";
 const QString Preferences::CRASH_REPORT_URL                 = QString::fromUtf8("http://g.api.mega.co.nz/hb?crashdump");
-const QString Preferences::UPDATE_FOLDER_NAME               = QString::fromAscii("update");
-const QString Preferences::UPDATE_BACKUP_FOLDER_NAME        = QString::fromAscii("backup");
+const QString Preferences::UPDATE_FOLDER_NAME               = QString::fromLatin1("update");
+const QString Preferences::UPDATE_BACKUP_FOLDER_NAME        = QString::fromLatin1("backup");
 const QString Preferences::PROXY_TEST_URL                   = QString::fromUtf8("https://g.api.mega.co.nz/cs");
 const QString Preferences::PROXY_TEST_SUBSTRING             = QString::fromUtf8("-2");
-const QString Preferences::syncsGroupKey            = QString::fromAscii("Syncs");
-const QString Preferences::currentAccountKey        = QString::fromAscii("currentAccount");
-const QString Preferences::emailKey                 = QString::fromAscii("email");
-const QString Preferences::firstNameKey             = QString::fromAscii("firstName");
-const QString Preferences::lastNameKey              = QString::fromAscii("lastName");
-const QString Preferences::emailHashKey             = QString::fromAscii("emailHash");
-const QString Preferences::privatePwKey             = QString::fromAscii("privatePw");
-const QString Preferences::totalStorageKey          = QString::fromAscii("totalStorage");
-const QString Preferences::usedStorageKey           = QString::fromAscii("usedStorage");
-const QString Preferences::cloudDriveStorageKey     = QString::fromAscii("cloudDriveStorage");
-const QString Preferences::inboxStorageKey          = QString::fromAscii("inboxStorage");
-const QString Preferences::rubbishStorageKey        = QString::fromAscii("rubbishStorage");
-const QString Preferences::inShareStorageKey        = QString::fromAscii("inShareStorage");
-const QString Preferences::versionsStorageKey        = QString::fromAscii("versionsStorage");
-const QString Preferences::cloudDriveFilesKey       = QString::fromAscii("cloudDriveFiles");
-const QString Preferences::inboxFilesKey            = QString::fromAscii("inboxFiles");
-const QString Preferences::rubbishFilesKey          = QString::fromAscii("rubbishFiles");
-const QString Preferences::inShareFilesKey          = QString::fromAscii("inShareFiles");
-const QString Preferences::cloudDriveFoldersKey     = QString::fromAscii("cloudDriveFolders");
-const QString Preferences::inboxFoldersKey          = QString::fromAscii("inboxFolders");
-const QString Preferences::rubbishFoldersKey        = QString::fromAscii("rubbishFolders");
-const QString Preferences::inShareFoldersKey        = QString::fromAscii("inShareFolders");
-const QString Preferences::totalBandwidthKey        = QString::fromAscii("totalBandwidth");
-const QString Preferences::usedBandwidthIntervalKey        = QString::fromAscii("usedBandwidthInterval");
-const QString Preferences::usedBandwidthKey         = QString::fromAscii("usedBandwidth");
+const QString Preferences::syncsGroupKey            = QString::fromLatin1("Syncs");
+const QString Preferences::currentAccountKey        = QString::fromLatin1("currentAccount");
+const QString Preferences::emailKey                 = QString::fromLatin1("email");
+const QString Preferences::firstNameKey             = QString::fromLatin1("firstName");
+const QString Preferences::lastNameKey              = QString::fromLatin1("lastName");
+const QString Preferences::emailHashKey             = QString::fromLatin1("emailHash");
+const QString Preferences::privatePwKey             = QString::fromLatin1("privatePw");
+const QString Preferences::totalStorageKey          = QString::fromLatin1("totalStorage");
+const QString Preferences::usedStorageKey           = QString::fromLatin1("usedStorage");
+const QString Preferences::cloudDriveStorageKey     = QString::fromLatin1("cloudDriveStorage");
+const QString Preferences::inboxStorageKey          = QString::fromLatin1("inboxStorage");
+const QString Preferences::rubbishStorageKey        = QString::fromLatin1("rubbishStorage");
+const QString Preferences::inShareStorageKey        = QString::fromLatin1("inShareStorage");
+const QString Preferences::versionsStorageKey        = QString::fromLatin1("versionsStorage");
+const QString Preferences::cloudDriveFilesKey       = QString::fromLatin1("cloudDriveFiles");
+const QString Preferences::inboxFilesKey            = QString::fromLatin1("inboxFiles");
+const QString Preferences::rubbishFilesKey          = QString::fromLatin1("rubbishFiles");
+const QString Preferences::inShareFilesKey          = QString::fromLatin1("inShareFiles");
+const QString Preferences::cloudDriveFoldersKey     = QString::fromLatin1("cloudDriveFolders");
+const QString Preferences::inboxFoldersKey          = QString::fromLatin1("inboxFolders");
+const QString Preferences::rubbishFoldersKey        = QString::fromLatin1("rubbishFolders");
+const QString Preferences::inShareFoldersKey        = QString::fromLatin1("inShareFolders");
+const QString Preferences::totalBandwidthKey        = QString::fromLatin1("totalBandwidth");
+const QString Preferences::usedBandwidthIntervalKey        = QString::fromLatin1("usedBandwidthInterval");
+const QString Preferences::usedBandwidthKey         = QString::fromLatin1("usedBandwidth");
 
-const QString Preferences::overStorageDialogExecutionKey = QString::fromAscii("overStorageDialogExecution");
-const QString Preferences::overStorageNotificationExecutionKey = QString::fromAscii("overStorageNotificationExecution");
-const QString Preferences::almostOverStorageNotificationExecutionKey = QString::fromAscii("almostOverStorageNotificationExecution");
-const QString Preferences::almostOverStorageDismissExecutionKey = QString::fromAscii("almostOverStorageDismissExecution");
-const QString Preferences::overStorageDismissExecutionKey = QString::fromAscii("overStorageDismissExecution");
-const QString Preferences::storageStateQKey = QString::fromAscii("storageStopLight");
+const QString Preferences::overStorageDialogExecutionKey = QString::fromLatin1("overStorageDialogExecution");
+const QString Preferences::overStorageNotificationExecutionKey = QString::fromLatin1("overStorageNotificationExecution");
+const QString Preferences::almostOverStorageNotificationExecutionKey = QString::fromLatin1("almostOverStorageNotificationExecution");
+const QString Preferences::almostOverStorageDismissExecutionKey = QString::fromLatin1("almostOverStorageDismissExecution");
+const QString Preferences::overStorageDismissExecutionKey = QString::fromLatin1("overStorageDismissExecution");
+const QString Preferences::storageStateQKey = QString::fromLatin1("storageStopLight");
 
-const QString Preferences::accountTypeKey           = QString::fromAscii("accountType");
-const QString Preferences::proExpirityTimeKey       = QString::fromAscii("proExpirityTime");
-const QString Preferences::showNotificationsKey     = QString::fromAscii("showNotifications");
-const QString Preferences::startOnStartupKey        = QString::fromAscii("startOnStartup");
-const QString Preferences::languageKey              = QString::fromAscii("language");
-const QString Preferences::updateAutomaticallyKey   = QString::fromAscii("updateAutomatically");
-const QString Preferences::uploadLimitKBKey         = QString::fromAscii("uploadLimitKB");
-const QString Preferences::downloadLimitKBKey       = QString::fromAscii("downloadLimitKB");
-const QString Preferences::parallelUploadConnectionsKey       = QString::fromAscii("parallelUploadConnections");
-const QString Preferences::parallelDownloadConnectionsKey     = QString::fromAscii("parallelDownloadConnections");
+const QString Preferences::accountTypeKey           = QString::fromLatin1("accountType");
+const QString Preferences::proExpirityTimeKey       = QString::fromLatin1("proExpirityTime");
+const QString Preferences::showNotificationsKey     = QString::fromLatin1("showNotifications");
+const QString Preferences::startOnStartupKey        = QString::fromLatin1("startOnStartup");
+const QString Preferences::languageKey              = QString::fromLatin1("language");
+const QString Preferences::updateAutomaticallyKey   = QString::fromLatin1("updateAutomatically");
+const QString Preferences::uploadLimitKBKey         = QString::fromLatin1("uploadLimitKB");
+const QString Preferences::downloadLimitKBKey       = QString::fromLatin1("downloadLimitKB");
+const QString Preferences::parallelUploadConnectionsKey       = QString::fromLatin1("parallelUploadConnections");
+const QString Preferences::parallelDownloadConnectionsKey     = QString::fromLatin1("parallelDownloadConnections");
 
-const QString Preferences::upperSizeLimitKey        = QString::fromAscii("upperSizeLimit");
-const QString Preferences::lowerSizeLimitKey        = QString::fromAscii("lowerSizeLimit");
+const QString Preferences::upperSizeLimitKey        = QString::fromLatin1("upperSizeLimit");
+const QString Preferences::lowerSizeLimitKey        = QString::fromLatin1("lowerSizeLimit");
 
-const QString Preferences::lastCustomStreamingAppKey    = QString::fromAscii("lastCustomStreamingApp");
-const QString Preferences::transferDownloadMethodKey    = QString::fromAscii("transferDownloadMethod");
-const QString Preferences::transferUploadMethodKey      = QString::fromAscii("transferUploadMethod");
+const QString Preferences::lastCustomStreamingAppKey    = QString::fromLatin1("lastCustomStreamingApp");
+const QString Preferences::transferDownloadMethodKey    = QString::fromLatin1("transferDownloadMethod");
+const QString Preferences::transferUploadMethodKey      = QString::fromLatin1("transferUploadMethod");
 
-const QString Preferences::upperSizeLimitValueKey       = QString::fromAscii("upperSizeLimitValue");
-const QString Preferences::lowerSizeLimitValueKey       = QString::fromAscii("lowerSizeLimitValue");
-const QString Preferences::upperSizeLimitUnitKey        = QString::fromAscii("upperSizeLimitUnit");
-const QString Preferences::lowerSizeLimitUnitKey        = QString::fromAscii("lowerSizeLimitUnit");
+const QString Preferences::upperSizeLimitValueKey       = QString::fromLatin1("upperSizeLimitValue");
+const QString Preferences::lowerSizeLimitValueKey       = QString::fromLatin1("lowerSizeLimitValue");
+const QString Preferences::upperSizeLimitUnitKey        = QString::fromLatin1("upperSizeLimitUnit");
+const QString Preferences::lowerSizeLimitUnitKey        = QString::fromLatin1("lowerSizeLimitUnit");
 
 
-const QString Preferences::cleanerDaysLimitKey       = QString::fromAscii("cleanerDaysLimit");
-const QString Preferences::cleanerDaysLimitValueKey  = QString::fromAscii("cleanerDaysLimitValue");
+const QString Preferences::cleanerDaysLimitKey       = QString::fromLatin1("cleanerDaysLimit");
+const QString Preferences::cleanerDaysLimitValueKey  = QString::fromLatin1("cleanerDaysLimitValue");
 
-const QString Preferences::folderPermissionsKey         = QString::fromAscii("folderPermissions");
-const QString Preferences::filePermissionsKey           = QString::fromAscii("filePermissions");
+const QString Preferences::folderPermissionsKey         = QString::fromLatin1("folderPermissions");
+const QString Preferences::filePermissionsKey           = QString::fromLatin1("filePermissions");
 
-const QString Preferences::proxyTypeKey             = QString::fromAscii("proxyType");
-const QString Preferences::proxyProtocolKey         = QString::fromAscii("proxyProtocol");
-const QString Preferences::proxyServerKey           = QString::fromAscii("proxyServer");
-const QString Preferences::proxyPortKey             = QString::fromAscii("proxyPort");
-const QString Preferences::proxyRequiresAuthKey     = QString::fromAscii("proxyRequiresAuth");
-const QString Preferences::proxyUsernameKey         = QString::fromAscii("proxyUsername");
-const QString Preferences::proxyPasswordKey         = QString::fromAscii("proxyPassword");
-const QString Preferences::syncNameKey              = QString::fromAscii("syncName");
-const QString Preferences::syncIdKey                = QString::fromAscii("syncId");
-const QString Preferences::localFolderKey           = QString::fromAscii("localFolder");
-const QString Preferences::megaFolderKey            = QString::fromAscii("megaFolder");
-const QString Preferences::megaFolderHandleKey      = QString::fromAscii("megaFolderHandle");
-const QString Preferences::folderActiveKey          = QString::fromAscii("folderActive");
-const QString Preferences::temporaryInactiveKey     = QString::fromAscii("temporaryInactive");
-const QString Preferences::downloadFolderKey        = QString::fromAscii("downloadFolder");
-const QString Preferences::uploadFolderKey          = QString::fromAscii("uploadFolder");
-const QString Preferences::importFolderKey          = QString::fromAscii("importFolder");
-const QString Preferences::hasDefaultUploadFolderKey    = QString::fromAscii("hasDefaultUploadFolder");
-const QString Preferences::hasDefaultDownloadFolderKey  = QString::fromAscii("hasDefaultDownloadFolder");
-const QString Preferences::hasDefaultImportFolderKey    = QString::fromAscii("hasDefaultImportFolder");
-const QString Preferences::fileNameKey              = QString::fromAscii("fileName");
-const QString Preferences::fileHandleKey            = QString::fromAscii("fileHandle");
-const QString Preferences::localPathKey             = QString::fromAscii("localPath");
-const QString Preferences::localFingerprintKey      = QString::fromAscii("localFingerprint");
-const QString Preferences::fileTimeKey              = QString::fromAscii("fileTime");
-const QString Preferences::isCrashedKey             = QString::fromAscii("isCrashed");
-const QString Preferences::wasPausedKey             = QString::fromAscii("wasPaused");
-const QString Preferences::wasUploadsPausedKey      = QString::fromAscii("wasUploadsPaused");
-const QString Preferences::wasDownloadsPausedKey    = QString::fromAscii("wasDownloadsPaused");
-const QString Preferences::lastExecutionTimeKey     = QString::fromAscii("lastExecutionTime");
-const QString Preferences::excludedSyncNamesKey     = QString::fromAscii("excludedSyncNames");
-const QString Preferences::excludedSyncPathsKey     = QString::fromAscii("excludedSyncPaths");
-const QString Preferences::lastVersionKey           = QString::fromAscii("lastVersion");
-const QString Preferences::lastStatsRequestKey      = QString::fromAscii("lastStatsRequest");
-const QString Preferences::lastUpdateTimeKey        = QString::fromAscii("lastUpdateTime");
-const QString Preferences::lastUpdateVersionKey     = QString::fromAscii("lastUpdateVersion");
-const QString Preferences::previousCrashesKey       = QString::fromAscii("previousCrashes");
-const QString Preferences::lastRebootKey            = QString::fromAscii("lastReboot");
-const QString Preferences::lastExitKey              = QString::fromAscii("lastExit");
-const QString Preferences::disableOverlayIconsKey   = QString::fromAscii("disableOverlayIcons");
-const QString Preferences::disableFileVersioningKey = QString::fromAscii("disableFileVersioning");
-const QString Preferences::disableLeftPaneIconsKey  = QString::fromAscii("disableLeftPaneIcons");
-const QString Preferences::sessionKey               = QString::fromAscii("session");
-const QString Preferences::firstStartDoneKey        = QString::fromAscii("firstStartDone");
-const QString Preferences::firstSyncDoneKey         = QString::fromAscii("firstSyncDone");
-const QString Preferences::firstFileSyncedKey       = QString::fromAscii("firstFileSynced");
-const QString Preferences::firstWebDownloadKey      = QString::fromAscii("firstWebclientDownload");
-const QString Preferences::fatWarningShownKey       = QString::fromAscii("fatWarningShown");
-const QString Preferences::installationTimeKey      = QString::fromAscii("installationTime");
-const QString Preferences::accountCreationTimeKey   = QString::fromAscii("accountCreationTime");
-const QString Preferences::hasLoggedInKey           = QString::fromAscii("hasLoggedIn");
-const QString Preferences::useHttpsOnlyKey          = QString::fromAscii("useHttpsOnly");
-const QString Preferences::SSLcertificateExceptionKey  = QString::fromAscii("SSLcertificateException");
-const QString Preferences::maxMemoryUsageKey        = QString::fromAscii("maxMemoryUsage");
-const QString Preferences::maxMemoryReportTimeKey   = QString::fromAscii("maxMemoryReportTime");
-const QString Preferences::oneTimeActionDoneKey     = QString::fromAscii("oneTimeActionDone");
-const QString Preferences::httpsKeyKey              = QString::fromAscii("httpsKey2");
-const QString Preferences::httpsCertKey             = QString::fromAscii("httpsCert2");
-const QString Preferences::httpsCertIntermediateKey = QString::fromAscii("httpsCertIntermediate2");
-const QString Preferences::httpsCertExpirationKey   = QString::fromAscii("httpsCertExpiration2");
-const QString Preferences::transferIdentifierKey    = QString::fromAscii("transferIdentifier");
-const QString Preferences::lastPublicHandleKey      = QString::fromAscii("lastPublicHandle");
-const QString Preferences::lastPublicHandleTimestampKey = QString::fromAscii("lastPublicHandleTimestamp");
+const QString Preferences::proxyTypeKey             = QString::fromLatin1("proxyType");
+const QString Preferences::proxyProtocolKey         = QString::fromLatin1("proxyProtocol");
+const QString Preferences::proxyServerKey           = QString::fromLatin1("proxyServer");
+const QString Preferences::proxyPortKey             = QString::fromLatin1("proxyPort");
+const QString Preferences::proxyRequiresAuthKey     = QString::fromLatin1("proxyRequiresAuth");
+const QString Preferences::proxyUsernameKey         = QString::fromLatin1("proxyUsername");
+const QString Preferences::proxyPasswordKey         = QString::fromLatin1("proxyPassword");
+const QString Preferences::syncNameKey              = QString::fromLatin1("syncName");
+const QString Preferences::syncIdKey                = QString::fromLatin1("syncId");
+const QString Preferences::localFolderKey           = QString::fromLatin1("localFolder");
+const QString Preferences::megaFolderKey            = QString::fromLatin1("megaFolder");
+const QString Preferences::megaFolderHandleKey      = QString::fromLatin1("megaFolderHandle");
+const QString Preferences::folderActiveKey          = QString::fromLatin1("folderActive");
+const QString Preferences::temporaryInactiveKey     = QString::fromLatin1("temporaryInactive");
+const QString Preferences::downloadFolderKey        = QString::fromLatin1("downloadFolder");
+const QString Preferences::uploadFolderKey          = QString::fromLatin1("uploadFolder");
+const QString Preferences::importFolderKey          = QString::fromLatin1("importFolder");
+const QString Preferences::hasDefaultUploadFolderKey    = QString::fromLatin1("hasDefaultUploadFolder");
+const QString Preferences::hasDefaultDownloadFolderKey  = QString::fromLatin1("hasDefaultDownloadFolder");
+const QString Preferences::hasDefaultImportFolderKey    = QString::fromLatin1("hasDefaultImportFolder");
+const QString Preferences::fileNameKey              = QString::fromLatin1("fileName");
+const QString Preferences::fileHandleKey            = QString::fromLatin1("fileHandle");
+const QString Preferences::localPathKey             = QString::fromLatin1("localPath");
+const QString Preferences::localFingerprintKey      = QString::fromLatin1("localFingerprint");
+const QString Preferences::fileTimeKey              = QString::fromLatin1("fileTime");
+const QString Preferences::isCrashedKey             = QString::fromLatin1("isCrashed");
+const QString Preferences::wasPausedKey             = QString::fromLatin1("wasPaused");
+const QString Preferences::wasUploadsPausedKey      = QString::fromLatin1("wasUploadsPaused");
+const QString Preferences::wasDownloadsPausedKey    = QString::fromLatin1("wasDownloadsPaused");
+const QString Preferences::lastExecutionTimeKey     = QString::fromLatin1("lastExecutionTime");
+const QString Preferences::excludedSyncNamesKey     = QString::fromLatin1("excludedSyncNames");
+const QString Preferences::excludedSyncPathsKey     = QString::fromLatin1("excludedSyncPaths");
+const QString Preferences::lastVersionKey           = QString::fromLatin1("lastVersion");
+const QString Preferences::lastStatsRequestKey      = QString::fromLatin1("lastStatsRequest");
+const QString Preferences::lastUpdateTimeKey        = QString::fromLatin1("lastUpdateTime");
+const QString Preferences::lastUpdateVersionKey     = QString::fromLatin1("lastUpdateVersion");
+const QString Preferences::previousCrashesKey       = QString::fromLatin1("previousCrashes");
+const QString Preferences::lastRebootKey            = QString::fromLatin1("lastReboot");
+const QString Preferences::lastExitKey              = QString::fromLatin1("lastExit");
+const QString Preferences::disableOverlayIconsKey   = QString::fromLatin1("disableOverlayIcons");
+const QString Preferences::disableFileVersioningKey = QString::fromLatin1("disableFileVersioning");
+const QString Preferences::disableLeftPaneIconsKey  = QString::fromLatin1("disableLeftPaneIcons");
+const QString Preferences::sessionKey               = QString::fromLatin1("session");
+const QString Preferences::firstStartDoneKey        = QString::fromLatin1("firstStartDone");
+const QString Preferences::firstSyncDoneKey         = QString::fromLatin1("firstSyncDone");
+const QString Preferences::firstFileSyncedKey       = QString::fromLatin1("firstFileSynced");
+const QString Preferences::firstWebDownloadKey      = QString::fromLatin1("firstWebclientDownload");
+const QString Preferences::fatWarningShownKey       = QString::fromLatin1("fatWarningShown");
+const QString Preferences::installationTimeKey      = QString::fromLatin1("installationTime");
+const QString Preferences::accountCreationTimeKey   = QString::fromLatin1("accountCreationTime");
+const QString Preferences::hasLoggedInKey           = QString::fromLatin1("hasLoggedIn");
+const QString Preferences::useHttpsOnlyKey          = QString::fromLatin1("useHttpsOnly");
+const QString Preferences::SSLcertificateExceptionKey  = QString::fromLatin1("SSLcertificateException");
+const QString Preferences::maxMemoryUsageKey        = QString::fromLatin1("maxMemoryUsage");
+const QString Preferences::maxMemoryReportTimeKey   = QString::fromLatin1("maxMemoryReportTime");
+const QString Preferences::oneTimeActionDoneKey     = QString::fromLatin1("oneTimeActionDone");
+const QString Preferences::httpsKeyKey              = QString::fromLatin1("httpsKey2");
+const QString Preferences::httpsCertKey             = QString::fromLatin1("httpsCert2");
+const QString Preferences::httpsCertIntermediateKey = QString::fromLatin1("httpsCertIntermediate2");
+const QString Preferences::httpsCertExpirationKey   = QString::fromLatin1("httpsCertExpiration2");
+const QString Preferences::transferIdentifierKey    = QString::fromLatin1("transferIdentifier");
+const QString Preferences::lastPublicHandleKey      = QString::fromLatin1("lastPublicHandle");
+const QString Preferences::lastPublicHandleTimestampKey = QString::fromLatin1("lastPublicHandleTimestamp");
 
 const bool Preferences::defaultShowNotifications    = true;
 const bool Preferences::defaultStartOnStartup       = true;
@@ -375,11 +375,11 @@ const int  Preferences::defaultProxyType            = Preferences::PROXY_TYPE_AU
 const int  Preferences::defaultProxyType            = Preferences::PROXY_TYPE_NONE;
 #endif
 const int  Preferences::defaultProxyProtocol        = Preferences::PROXY_PROTOCOL_HTTP;
-const QString  Preferences::defaultProxyServer      = QString::fromAscii("127.0.0.1");
+const QString  Preferences::defaultProxyServer      = QString::fromLatin1("127.0.0.1");
 const int Preferences::defaultProxyPort             = 8080;
 const bool Preferences::defaultProxyRequiresAuth    = false;
-const QString Preferences::defaultProxyUsername     = QString::fromAscii("");
-const QString Preferences::defaultProxyPassword     = QString::fromAscii("");
+const QString Preferences::defaultProxyUsername     = QString::fromLatin1("");
+const QString Preferences::defaultProxyPassword     = QString::fromLatin1("");
 
 Preferences *Preferences::preferences = NULL;
 
@@ -402,14 +402,14 @@ void Preferences::initialize(QString dataPath)
 {
     this->dataPath = dataPath;
 #if QT_VERSION >= 0x050000
-    QString lockSettingsFile = QDir::toNativeSeparators(dataPath + QString::fromAscii("/MEGAsync.cfg.lock"));
+    QString lockSettingsFile = QDir::toNativeSeparators(dataPath + QString::fromLatin1("/MEGAsync.cfg.lock"));
     QFile::remove(lockSettingsFile);
 #endif
 
     QDir dir(dataPath);
-    dir.mkpath(QString::fromAscii("."));
-    QString settingsFile = QDir::toNativeSeparators(dataPath + QString::fromAscii("/MEGAsync.cfg"));
-    QString bakSettingsFile = QDir::toNativeSeparators(dataPath + QString::fromAscii("/MEGAsync.cfg.bak"));
+    dir.mkpath(QString::fromLatin1("."));
+    QString settingsFile = QDir::toNativeSeparators(dataPath + QString::fromLatin1("/MEGAsync.cfg"));
+    QString bakSettingsFile = QDir::toNativeSeparators(dataPath + QString::fromLatin1("/MEGAsync.cfg.bak"));
     bool retryFlag = false;
 
     errorFlag = false;
@@ -1703,11 +1703,11 @@ QString Preferences::proxyHostAndPort()
     QHostAddress ipAddress(hostname);
     if (ipAddress.protocol() == QAbstractSocket::IPv6Protocol)
     {
-        proxy = QString::fromUtf8("[") + hostname + QString::fromAscii("]:") + QString::number(proxyPort());
+        proxy = QString::fromUtf8("[") + hostname + QString::fromLatin1("]:") + QString::number(proxyPort());
     }
     else
     {
-        proxy = hostname + QString::fromAscii(":") + QString::number(proxyPort());
+        proxy = hostname + QString::fromLatin1(":") + QString::number(proxyPort());
     }
 
     mutex.unlock();
@@ -2242,7 +2242,7 @@ void Preferences::addSyncedFolder(QString localFolder, QString megaFolder, mega:
         syncName = QDir::toNativeSeparators(localFolder);
     }
 
-    syncName.remove(QChar::fromAscii(':')).remove(QDir::separator());
+    syncName.remove(QChar::fromLatin1(':')).remove(QDir::separator());
 
     localFolder = QDir::toNativeSeparators(localFolderInfo.canonicalFilePath());
     syncNames.append(syncName);
@@ -2330,7 +2330,7 @@ void Preferences::setExcludedSyncNames(QStringList names)
     }
     else
     {
-        settings->setValue(excludedSyncNamesKey, excludedSyncNames.join(QString::fromAscii("\n")));
+        settings->setValue(excludedSyncNamesKey, excludedSyncNames.join(QString::fromLatin1("\n")));
     }
 
     settings->sync();
@@ -2357,7 +2357,7 @@ void Preferences::setExcludedSyncPaths(QStringList paths)
     }
     else
     {
-        settings->setValue(excludedSyncPathsKey, excludedSyncPaths.join(QString::fromAscii("\n")));
+        settings->setValue(excludedSyncPathsKey, excludedSyncPaths.join(QString::fromLatin1("\n")));
     }
 
     settings->sync();
@@ -2374,7 +2374,7 @@ QStringList Preferences::getPreviousCrashes()
         settings->endGroup();
         currentAccount = settings->value(currentAccountKey).toString();
     }
-    previousCrashes = settings->value(previousCrashesKey).toString().split(QString::fromAscii("\n", QString::SkipEmptyParts));
+    previousCrashes = settings->value(previousCrashesKey).toString().split(QString::fromLatin1("\n", QString::SkipEmptyParts));
     if (!currentAccount.isEmpty())
     {
         settings->beginGroup(currentAccount);
@@ -2400,7 +2400,7 @@ void Preferences::setPreviousCrashes(QStringList crashes)
     }
     else
     {
-        settings->setValue(previousCrashesKey, crashes.join(QString::fromAscii("\n")));
+        settings->setValue(previousCrashesKey, crashes.join(QString::fromLatin1("\n")));
     }
 
     if (!currentAccount.isEmpty())
@@ -2959,7 +2959,7 @@ bool Preferences::hasEmail(QString email)
         value = !storedEmail.compare(email);
         if (!value)
         {
-            settings->remove(QString::fromAscii(""));
+            settings->remove(QString::fromLatin1(""));
         }
         settings->endGroup();
     }
@@ -2994,13 +2994,13 @@ static bool caseInsensitiveLessThan(const QString &s1, const QString &s2)
 void Preferences::loadExcludedSyncNames()
 {
     mutex.lock();
-    excludedSyncNames = settings->value(excludedSyncNamesKey).toString().split(QString::fromAscii("\n", QString::SkipEmptyParts));
+    excludedSyncNames = settings->value(excludedSyncNamesKey).toString().split(QString::fromLatin1("\n", QString::SkipEmptyParts));
     if (excludedSyncNames.size()==1 && excludedSyncNames.at(0).isEmpty())
     {
         excludedSyncNames.clear();
     }
 
-    excludedSyncPaths = settings->value(excludedSyncPathsKey).toString().split(QString::fromAscii("\n", QString::SkipEmptyParts));
+    excludedSyncPaths = settings->value(excludedSyncPathsKey).toString().split(QString::fromLatin1("\n", QString::SkipEmptyParts));
     if (excludedSyncPaths.size()==1 && excludedSyncPaths.at(0).isEmpty())
     {
         excludedSyncPaths.clear();
@@ -3082,7 +3082,7 @@ void Preferences::writeFolders()
 
     settings->beginGroup(syncsGroupKey);
 
-    settings->remove(QString::fromAscii(""));
+    settings->remove(QString::fromLatin1(""));
     for (int i = 0; i < localFolders.size(); i++)
     {
         settings->beginGroup(QString::number(i));

--- a/src/MEGASync/control/UpdateTask.cpp
+++ b/src/MEGASync/control/UpdateTask.cpp
@@ -91,7 +91,7 @@ void UpdateTask::tryUpdate()
     QString randomSequence = QString::fromUtf8("?");
     for (int i = 0; i < 10; i++)
     {
-        randomSequence += QChar::fromAscii('A'+(rand() % 26));
+        randomSequence += QChar::fromLatin1('A'+(rand() % 26));
     }
 
     downloadFile(Preferences::UPDATE_CHECK_URL + randomSequence);
@@ -281,7 +281,7 @@ bool UpdateTask::processUpdateFile(QNetworkReply *reply)
 
         int intVersion = 0;
         QDir dataDir(preferences->getDataPath());
-        QString appVersionPath = dataDir.filePath(QString::fromAscii("megasync.version"));
+        QString appVersionPath = dataDir.filePath(QString::fromLatin1("megasync.version"));
         QFile f(appVersionPath);
         if (f.open(QFile::ReadOnly | QFile::Text))
         {
@@ -324,7 +324,7 @@ bool UpdateTask::processFile(QNetworkReply *reply)
     //Create the folder for the new file
     QFile localFile(updateFolder.absoluteFilePath(localPaths[currentFile]));
     QFileInfo info(localFile);
-    info.absoluteDir().mkpath(QString::fromAscii("."));
+    info.absoluteDir().mkpath(QString::fromLatin1("."));
 
     //Delete the file if it exists.
     localFile.remove();
@@ -378,8 +378,8 @@ bool UpdateTask::performUpdate()
 
     //Create backup folder
     QDir basePathDir(basePath);
-    backupFolder = QDir(basePathDir.absoluteFilePath(Preferences::UPDATE_BACKUP_FOLDER_NAME + QDateTime::currentDateTime().toString(QString::fromAscii("_dd_MM_yy__hh_mm_ss"))));
-    backupFolder.mkdir(QString::fromAscii("."));
+    backupFolder = QDir(basePathDir.absoluteFilePath(Preferences::UPDATE_BACKUP_FOLDER_NAME + QDateTime::currentDateTime().toString(QString::fromLatin1("_dd_MM_yy__hh_mm_ss"))));
+    backupFolder.mkdir(QString::fromLatin1("."));
 
     for (int i = 0; i < localPaths.size(); i++)
     {
@@ -527,12 +527,12 @@ void UpdateTask::downloadFinished(QNetworkReply *reply)
     {
         if (!alreadyDownloaded(localPaths[currentFile], fileSignatures[currentFile]))
         {
-            MegaApi::log(MegaApi::LOG_LEVEL_INFO, QString::fromAscii("Downloading file: %1").arg(downloadURLs[currentFile]).toUtf8().constData());
+            MegaApi::log(MegaApi::LOG_LEVEL_INFO, QString::fromLatin1("Downloading file: %1").arg(downloadURLs[currentFile]).toUtf8().constData());
             downloadFile(downloadURLs[currentFile]);
             return;
         }
 
-        MegaApi::log(MegaApi::LOG_LEVEL_INFO, QString::fromAscii("File already downloaded: %1").arg(localPaths[currentFile]).toUtf8().constData());
+        MegaApi::log(MegaApi::LOG_LEVEL_INFO, QString::fromLatin1("File already downloaded: %1").arg(localPaths[currentFile]).toUtf8().constData());
         currentFile++;
     }
 

--- a/src/MEGASync/control/Utilities.cpp
+++ b/src/MEGASync/control/Utilities.cpp
@@ -23,115 +23,115 @@ QHash<QString, QString> Utilities::languageNames;
 
 void Utilities::initializeExtensions()
 {
-    extensionIcons[QString::fromAscii("3ds")] = extensionIcons[QString::fromAscii("3dm")]  = extensionIcons[QString::fromAscii("max")] =
-                            extensionIcons[QString::fromAscii("obj")]  = QString::fromAscii("3D.png");
+    extensionIcons[QString::fromLatin1("3ds")] = extensionIcons[QString::fromLatin1("3dm")]  = extensionIcons[QString::fromLatin1("max")] =
+                            extensionIcons[QString::fromLatin1("obj")]  = QString::fromLatin1("3D.png");
 
-    extensionIcons[QString::fromAscii("aep")] = extensionIcons[QString::fromAscii("aet")]  = QString::fromAscii("aftereffects.png");
+    extensionIcons[QString::fromLatin1("aep")] = extensionIcons[QString::fromLatin1("aet")]  = QString::fromLatin1("aftereffects.png");
 
-    extensionIcons[QString::fromAscii("mp3")] = extensionIcons[QString::fromAscii("wav")]  = extensionIcons[QString::fromAscii("3ga")]  =
-                            extensionIcons[QString::fromAscii("aif")]  = extensionIcons[QString::fromAscii("aiff")] =
-                            extensionIcons[QString::fromAscii("flac")] = extensionIcons[QString::fromAscii("iff")]  =
-                            extensionIcons[QString::fromAscii("m4a")]  = extensionIcons[QString::fromAscii("wma")]  =  QString::fromAscii("audio.png");
+    extensionIcons[QString::fromLatin1("mp3")] = extensionIcons[QString::fromLatin1("wav")]  = extensionIcons[QString::fromLatin1("3ga")]  =
+                            extensionIcons[QString::fromLatin1("aif")]  = extensionIcons[QString::fromLatin1("aiff")] =
+                            extensionIcons[QString::fromLatin1("flac")] = extensionIcons[QString::fromLatin1("iff")]  =
+                            extensionIcons[QString::fromLatin1("m4a")]  = extensionIcons[QString::fromLatin1("wma")]  =  QString::fromLatin1("audio.png");
 
-    extensionIcons[QString::fromAscii("dxf")] = extensionIcons[QString::fromAscii("dwg")] =  QString::fromAscii("cad.png");
+    extensionIcons[QString::fromLatin1("dxf")] = extensionIcons[QString::fromLatin1("dwg")] =  QString::fromLatin1("cad.png");
 
 
-    extensionIcons[QString::fromAscii("zip")] = extensionIcons[QString::fromAscii("rar")] = extensionIcons[QString::fromAscii("tgz")]  =
-                            extensionIcons[QString::fromAscii("gz")]  = extensionIcons[QString::fromAscii("bz2")]  =
-                            extensionIcons[QString::fromAscii("tbz")] = extensionIcons[QString::fromAscii("tar")]  =
-                            extensionIcons[QString::fromAscii("7z")]  = extensionIcons[QString::fromAscii("sitx")] =  QString::fromAscii("compressed.png");
+    extensionIcons[QString::fromLatin1("zip")] = extensionIcons[QString::fromLatin1("rar")] = extensionIcons[QString::fromLatin1("tgz")]  =
+                            extensionIcons[QString::fromLatin1("gz")]  = extensionIcons[QString::fromLatin1("bz2")]  =
+                            extensionIcons[QString::fromLatin1("tbz")] = extensionIcons[QString::fromLatin1("tar")]  =
+                            extensionIcons[QString::fromLatin1("7z")]  = extensionIcons[QString::fromLatin1("sitx")] =  QString::fromLatin1("compressed.png");
 
-    extensionIcons[QString::fromAscii("sql")] = extensionIcons[QString::fromAscii("accdb")] = extensionIcons[QString::fromAscii("db")]  =
-                            extensionIcons[QString::fromAscii("dbf")]  = extensionIcons[QString::fromAscii("mdb")]  =
-                            extensionIcons[QString::fromAscii("pdb")] = QString::fromAscii("web_lang.png");
+    extensionIcons[QString::fromLatin1("sql")] = extensionIcons[QString::fromLatin1("accdb")] = extensionIcons[QString::fromLatin1("db")]  =
+                            extensionIcons[QString::fromLatin1("dbf")]  = extensionIcons[QString::fromLatin1("mdb")]  =
+                            extensionIcons[QString::fromLatin1("pdb")] = QString::fromLatin1("web_lang.png");
 
-    extensionIcons[QString::fromAscii("folder")] = QString::fromAscii("folder.png");
+    extensionIcons[QString::fromLatin1("folder")] = QString::fromLatin1("folder.png");
 
-    extensionIcons[QString::fromAscii("xls")] = extensionIcons[QString::fromAscii("xlsx")] = extensionIcons[QString::fromAscii("xlt")]  =
-                            extensionIcons[QString::fromAscii("xltm")]  = QString::fromAscii("excel.png");
+    extensionIcons[QString::fromLatin1("xls")] = extensionIcons[QString::fromLatin1("xlsx")] = extensionIcons[QString::fromLatin1("xlt")]  =
+                            extensionIcons[QString::fromLatin1("xltm")]  = QString::fromLatin1("excel.png");
 
-    extensionIcons[QString::fromAscii("exe")] = extensionIcons[QString::fromAscii("com")] = extensionIcons[QString::fromAscii("bin")]  =
-                            extensionIcons[QString::fromAscii("apk")]  = extensionIcons[QString::fromAscii("app")]  =
-                             extensionIcons[QString::fromAscii("msi")]  = extensionIcons[QString::fromAscii("cmd")]  =
-                            extensionIcons[QString::fromAscii("gadget")] = QString::fromAscii("executable.png");
+    extensionIcons[QString::fromLatin1("exe")] = extensionIcons[QString::fromLatin1("com")] = extensionIcons[QString::fromLatin1("bin")]  =
+                            extensionIcons[QString::fromLatin1("apk")]  = extensionIcons[QString::fromLatin1("app")]  =
+                             extensionIcons[QString::fromLatin1("msi")]  = extensionIcons[QString::fromLatin1("cmd")]  =
+                            extensionIcons[QString::fromLatin1("gadget")] = QString::fromLatin1("executable.png");
 
-    extensionIcons[QString::fromAscii("fnt")] = extensionIcons[QString::fromAscii("otf")] = extensionIcons[QString::fromAscii("ttf")]  =
-                            extensionIcons[QString::fromAscii("fon")]  = QString::fromAscii("font.png");
+    extensionIcons[QString::fromLatin1("fnt")] = extensionIcons[QString::fromLatin1("otf")] = extensionIcons[QString::fromLatin1("ttf")]  =
+                            extensionIcons[QString::fromLatin1("fon")]  = QString::fromLatin1("font.png");
 
-    extensionIcons[QString::fromAscii("gif")] = extensionIcons[QString::fromAscii("tiff")]  = extensionIcons[QString::fromAscii("tif")]  =
-                            extensionIcons[QString::fromAscii("bmp")]  = extensionIcons[QString::fromAscii("png")] =
-                            extensionIcons[QString::fromAscii("tga")]  = QString::fromAscii("image.png");
+    extensionIcons[QString::fromLatin1("gif")] = extensionIcons[QString::fromLatin1("tiff")]  = extensionIcons[QString::fromLatin1("tif")]  =
+                            extensionIcons[QString::fromLatin1("bmp")]  = extensionIcons[QString::fromLatin1("png")] =
+                            extensionIcons[QString::fromLatin1("tga")]  = QString::fromLatin1("image.png");
 
-    extensionIcons[QString::fromAscii("ai")] = extensionIcons[QString::fromAscii("ait")] = QString::fromAscii("illustrator.png");
-    extensionIcons[QString::fromAscii("jpg")] = extensionIcons[QString::fromAscii("jpeg")] = QString::fromAscii("image.png");
-    extensionIcons[QString::fromAscii("indd")] = QString::fromAscii("indesign.png");
+    extensionIcons[QString::fromLatin1("ai")] = extensionIcons[QString::fromLatin1("ait")] = QString::fromLatin1("illustrator.png");
+    extensionIcons[QString::fromLatin1("jpg")] = extensionIcons[QString::fromLatin1("jpeg")] = QString::fromLatin1("image.png");
+    extensionIcons[QString::fromLatin1("indd")] = QString::fromLatin1("indesign.png");
 
-    extensionIcons[QString::fromAscii("jar")] = extensionIcons[QString::fromAscii("java")]  = extensionIcons[QString::fromAscii("class")]  = QString::fromAscii("web_data.png");
+    extensionIcons[QString::fromLatin1("jar")] = extensionIcons[QString::fromLatin1("java")]  = extensionIcons[QString::fromLatin1("class")]  = QString::fromLatin1("web_data.png");
 
-    extensionIcons[QString::fromAscii("pdf")] = QString::fromAscii("pdf.png");
-    extensionIcons[QString::fromAscii("abr")] = extensionIcons[QString::fromAscii("psb")]  = extensionIcons[QString::fromAscii("psd")]  =
-                            QString::fromAscii("photoshop.png");
+    extensionIcons[QString::fromLatin1("pdf")] = QString::fromLatin1("pdf.png");
+    extensionIcons[QString::fromLatin1("abr")] = extensionIcons[QString::fromLatin1("psb")]  = extensionIcons[QString::fromLatin1("psd")]  =
+                            QString::fromLatin1("photoshop.png");
 
-    extensionIcons[QString::fromAscii("pps")] = extensionIcons[QString::fromAscii("ppt")]  = extensionIcons[QString::fromAscii("pptx")] = QString::fromAscii("powerpoint.png");
+    extensionIcons[QString::fromLatin1("pps")] = extensionIcons[QString::fromLatin1("ppt")]  = extensionIcons[QString::fromLatin1("pptx")] = QString::fromLatin1("powerpoint.png");
 
-    extensionIcons[QString::fromAscii("prproj")] = extensionIcons[QString::fromAscii("ppj")]  = QString::fromAscii("premiere.png");
+    extensionIcons[QString::fromLatin1("prproj")] = extensionIcons[QString::fromLatin1("ppj")]  = QString::fromLatin1("premiere.png");
 
-    extensionIcons[QString::fromAscii("3fr")] = extensionIcons[QString::fromAscii("arw")]  = extensionIcons[QString::fromAscii("bay")]  =
-                            extensionIcons[QString::fromAscii("cr2")]  = extensionIcons[QString::fromAscii("dcr")] =
-                            extensionIcons[QString::fromAscii("dng")] = extensionIcons[QString::fromAscii("fff")]  =
-                            extensionIcons[QString::fromAscii("mef")] = extensionIcons[QString::fromAscii("mrw")]  =
-                            extensionIcons[QString::fromAscii("nef")] = extensionIcons[QString::fromAscii("pef")]  =
-                            extensionIcons[QString::fromAscii("rw2")] = extensionIcons[QString::fromAscii("srf")]  =
-                            extensionIcons[QString::fromAscii("orf")] = extensionIcons[QString::fromAscii("rwl")]  =
-                            QString::fromAscii("raw.png");
+    extensionIcons[QString::fromLatin1("3fr")] = extensionIcons[QString::fromLatin1("arw")]  = extensionIcons[QString::fromLatin1("bay")]  =
+                            extensionIcons[QString::fromLatin1("cr2")]  = extensionIcons[QString::fromLatin1("dcr")] =
+                            extensionIcons[QString::fromLatin1("dng")] = extensionIcons[QString::fromLatin1("fff")]  =
+                            extensionIcons[QString::fromLatin1("mef")] = extensionIcons[QString::fromLatin1("mrw")]  =
+                            extensionIcons[QString::fromLatin1("nef")] = extensionIcons[QString::fromLatin1("pef")]  =
+                            extensionIcons[QString::fromLatin1("rw2")] = extensionIcons[QString::fromLatin1("srf")]  =
+                            extensionIcons[QString::fromLatin1("orf")] = extensionIcons[QString::fromLatin1("rwl")]  =
+                            QString::fromLatin1("raw.png");
 
-    extensionIcons[QString::fromAscii("ods")]  = extensionIcons[QString::fromAscii("ots")]  =
-                            extensionIcons[QString::fromAscii("gsheet")]  = extensionIcons[QString::fromAscii("nb")] =
-                            extensionIcons[QString::fromAscii("xlr")] = QString::fromAscii("spreadsheet.png");
+    extensionIcons[QString::fromLatin1("ods")]  = extensionIcons[QString::fromLatin1("ots")]  =
+                            extensionIcons[QString::fromLatin1("gsheet")]  = extensionIcons[QString::fromLatin1("nb")] =
+                            extensionIcons[QString::fromLatin1("xlr")] = QString::fromLatin1("spreadsheet.png");
 
-    extensionIcons[QString::fromAscii("torrent")] = QString::fromAscii("torrent.png");
-    extensionIcons[QString::fromAscii("dmg")] = QString::fromAscii("dmg.png");
+    extensionIcons[QString::fromLatin1("torrent")] = QString::fromLatin1("torrent.png");
+    extensionIcons[QString::fromLatin1("dmg")] = QString::fromLatin1("dmg.png");
 
-    extensionIcons[QString::fromAscii("txt")] = extensionIcons[QString::fromAscii("rtf")]  = extensionIcons[QString::fromAscii("ans")]  =
-                            extensionIcons[QString::fromAscii("ascii")]  = extensionIcons[QString::fromAscii("log")] =
-                            extensionIcons[QString::fromAscii("odt")] = extensionIcons[QString::fromAscii("wpd")]  =
-                            QString::fromAscii("text.png");
+    extensionIcons[QString::fromLatin1("txt")] = extensionIcons[QString::fromLatin1("rtf")]  = extensionIcons[QString::fromLatin1("ans")]  =
+                            extensionIcons[QString::fromLatin1("ascii")]  = extensionIcons[QString::fromLatin1("log")] =
+                            extensionIcons[QString::fromLatin1("odt")] = extensionIcons[QString::fromLatin1("wpd")]  =
+                            QString::fromLatin1("text.png");
 
-    extensionIcons[QString::fromAscii("svgz")]  = extensionIcons[QString::fromAscii("svg")]  =
-                            extensionIcons[QString::fromAscii("cdr")]  = extensionIcons[QString::fromAscii("eps")] =
-                            QString::fromAscii("vector.png");
+    extensionIcons[QString::fromLatin1("svgz")]  = extensionIcons[QString::fromLatin1("svg")]  =
+                            extensionIcons[QString::fromLatin1("cdr")]  = extensionIcons[QString::fromLatin1("eps")] =
+                            QString::fromLatin1("vector.png");
 
-     extensionIcons[QString::fromAscii("mkv")]  = extensionIcons[QString::fromAscii("webm")]  =
-                            extensionIcons[QString::fromAscii("avi")]  = extensionIcons[QString::fromAscii("mp4")] =
-                            extensionIcons[QString::fromAscii("m4v")] = extensionIcons[QString::fromAscii("mpg")]  =
-                            extensionIcons[QString::fromAscii("mpeg")] = extensionIcons[QString::fromAscii("mov")]  =
-                            extensionIcons[QString::fromAscii("3g2")] = extensionIcons[QString::fromAscii("3gp")]  =
-                            extensionIcons[QString::fromAscii("asf")] = extensionIcons[QString::fromAscii("wmv")]  =
-                            extensionIcons[QString::fromAscii("flv")] = extensionIcons[QString::fromAscii("vob")] =
-                            QString::fromAscii("video.png");
+     extensionIcons[QString::fromLatin1("mkv")]  = extensionIcons[QString::fromLatin1("webm")]  =
+                            extensionIcons[QString::fromLatin1("avi")]  = extensionIcons[QString::fromLatin1("mp4")] =
+                            extensionIcons[QString::fromLatin1("m4v")] = extensionIcons[QString::fromLatin1("mpg")]  =
+                            extensionIcons[QString::fromLatin1("mpeg")] = extensionIcons[QString::fromLatin1("mov")]  =
+                            extensionIcons[QString::fromLatin1("3g2")] = extensionIcons[QString::fromLatin1("3gp")]  =
+                            extensionIcons[QString::fromLatin1("asf")] = extensionIcons[QString::fromLatin1("wmv")]  =
+                            extensionIcons[QString::fromLatin1("flv")] = extensionIcons[QString::fromLatin1("vob")] =
+                            QString::fromLatin1("video.png");
 
-     extensionIcons[QString::fromAscii("html")]  = extensionIcons[QString::fromAscii("xml")] = extensionIcons[QString::fromAscii("shtml")]  =
-                            extensionIcons[QString::fromAscii("dhtml")] = extensionIcons[QString::fromAscii("js")] =
-                            extensionIcons[QString::fromAscii("css")]  = QString::fromAscii("web_data.png");
+     extensionIcons[QString::fromLatin1("html")]  = extensionIcons[QString::fromLatin1("xml")] = extensionIcons[QString::fromLatin1("shtml")]  =
+                            extensionIcons[QString::fromLatin1("dhtml")] = extensionIcons[QString::fromLatin1("js")] =
+                            extensionIcons[QString::fromLatin1("css")]  = QString::fromLatin1("web_data.png");
 
-     extensionIcons[QString::fromAscii("php")]  = extensionIcons[QString::fromAscii("php3")]  =
-                            extensionIcons[QString::fromAscii("php4")]  = extensionIcons[QString::fromAscii("php5")] =
-                            extensionIcons[QString::fromAscii("phtml")] = extensionIcons[QString::fromAscii("inc")]  =
-                            extensionIcons[QString::fromAscii("asp")] = extensionIcons[QString::fromAscii("pl")]  =
-                            extensionIcons[QString::fromAscii("cgi")] = extensionIcons[QString::fromAscii("py")]  =
-                            QString::fromAscii("web_lang.png");
+     extensionIcons[QString::fromLatin1("php")]  = extensionIcons[QString::fromLatin1("php3")]  =
+                            extensionIcons[QString::fromLatin1("php4")]  = extensionIcons[QString::fromLatin1("php5")] =
+                            extensionIcons[QString::fromLatin1("phtml")] = extensionIcons[QString::fromLatin1("inc")]  =
+                            extensionIcons[QString::fromLatin1("asp")] = extensionIcons[QString::fromLatin1("pl")]  =
+                            extensionIcons[QString::fromLatin1("cgi")] = extensionIcons[QString::fromLatin1("py")]  =
+                            QString::fromLatin1("web_lang.png");
 
-     extensionIcons[QString::fromAscii("doc")]  = extensionIcons[QString::fromAscii("docx")] = extensionIcons[QString::fromAscii("dotx")]  =
-                            extensionIcons[QString::fromAscii("wps")] = QString::fromAscii("word.png");
+     extensionIcons[QString::fromLatin1("doc")]  = extensionIcons[QString::fromLatin1("docx")] = extensionIcons[QString::fromLatin1("dotx")]  =
+                            extensionIcons[QString::fromLatin1("wps")] = QString::fromLatin1("word.png");
 
-     extensionIcons[QString::fromAscii("odt")]  = extensionIcons[QString::fromAscii("ods")] = extensionIcons[QString::fromAscii("odp")]  =
-                            extensionIcons[QString::fromAscii("odb")] = extensionIcons[QString::fromAscii("odg")] = QString::fromAscii("openoffice.png");
+     extensionIcons[QString::fromLatin1("odt")]  = extensionIcons[QString::fromLatin1("ods")] = extensionIcons[QString::fromLatin1("odp")]  =
+                            extensionIcons[QString::fromLatin1("odb")] = extensionIcons[QString::fromLatin1("odg")] = QString::fromLatin1("openoffice.png");
 
-     extensionIcons[QString::fromAscii("sketch")] = QString::fromAscii("sketch.png");
-     extensionIcons[QString::fromAscii("xd")] = QString::fromAscii("experiencedesign.png");
-     extensionIcons[QString::fromAscii("pages")] = QString::fromAscii("pages.png");
-     extensionIcons[QString::fromAscii("numbers")] = QString::fromAscii("numbers.png");
-     extensionIcons[QString::fromAscii("key")] = QString::fromAscii("keynote.png");
+     extensionIcons[QString::fromLatin1("sketch")] = QString::fromLatin1("sketch.png");
+     extensionIcons[QString::fromLatin1("xd")] = QString::fromLatin1("experiencedesign.png");
+     extensionIcons[QString::fromLatin1("pages")] = QString::fromLatin1("pages.png");
+     extensionIcons[QString::fromLatin1("numbers")] = QString::fromLatin1("numbers.png");
+     extensionIcons[QString::fromLatin1("key")] = QString::fromLatin1("keynote.png");
 }
 
 void Utilities::getFolderSize(QString folderPath, long long *size)
@@ -180,7 +180,7 @@ QString Utilities::getExtensionPixmap(QString fileName, QString prefix)
     }
     else
     {
-        return prefix + QString::fromAscii("generic.png");
+        return prefix + QString::fromLatin1("generic.png");
     }
 }
 
@@ -188,58 +188,58 @@ QString Utilities::languageCodeToString(QString code)
 {
     if (languageNames.isEmpty())
     {       
-        languageNames[QString::fromAscii("ar")] = QString::fromUtf8("العربية");
-        languageNames[QString::fromAscii("de")] = QString::fromUtf8("Deutsch");  
-        languageNames[QString::fromAscii("en")] = QString::fromUtf8("English");
-        languageNames[QString::fromAscii("es")] = QString::fromUtf8("Español");
-        languageNames[QString::fromAscii("fr")] = QString::fromUtf8("Français");
-        languageNames[QString::fromAscii("id")] = QString::fromUtf8("Bahasa Indonesia");
-        languageNames[QString::fromAscii("it")] = QString::fromUtf8("Italiano");
-        languageNames[QString::fromAscii("ja")] = QString::fromUtf8("日本語");
-        languageNames[QString::fromAscii("ko")] = QString::fromUtf8("한국어");
-        languageNames[QString::fromAscii("nl")] = QString::fromUtf8("Nederlands");
-        languageNames[QString::fromAscii("pl")] = QString::fromUtf8("Polski");
-        languageNames[QString::fromAscii("pt_BR")] = QString::fromUtf8("Português Brasil");
-        languageNames[QString::fromAscii("pt")] = QString::fromUtf8("Português");
-        languageNames[QString::fromAscii("ro")] = QString::fromUtf8("Română");
-        languageNames[QString::fromAscii("ru")] = QString::fromUtf8("Pусский");
-        languageNames[QString::fromAscii("th")] = QString::fromUtf8("ภาษาไทย");
-        languageNames[QString::fromAscii("tl")] = QString::fromUtf8("Tagalog");
-        languageNames[QString::fromAscii("uk")] = QString::fromUtf8("Українська");
-        languageNames[QString::fromAscii("vi")] = QString::fromUtf8("Tiếng Việt");
-        languageNames[QString::fromAscii("zh_CN")] = QString::fromUtf8("简体中文");
-        languageNames[QString::fromAscii("zh_TW")] = QString::fromUtf8("中文繁體");
+        languageNames[QString::fromLatin1("ar")] = QString::fromUtf8("العربية");
+        languageNames[QString::fromLatin1("de")] = QString::fromUtf8("Deutsch");  
+        languageNames[QString::fromLatin1("en")] = QString::fromUtf8("English");
+        languageNames[QString::fromLatin1("es")] = QString::fromUtf8("Español");
+        languageNames[QString::fromLatin1("fr")] = QString::fromUtf8("Français");
+        languageNames[QString::fromLatin1("id")] = QString::fromUtf8("Bahasa Indonesia");
+        languageNames[QString::fromLatin1("it")] = QString::fromUtf8("Italiano");
+        languageNames[QString::fromLatin1("ja")] = QString::fromUtf8("日本語");
+        languageNames[QString::fromLatin1("ko")] = QString::fromUtf8("한국어");
+        languageNames[QString::fromLatin1("nl")] = QString::fromUtf8("Nederlands");
+        languageNames[QString::fromLatin1("pl")] = QString::fromUtf8("Polski");
+        languageNames[QString::fromLatin1("pt_BR")] = QString::fromUtf8("Português Brasil");
+        languageNames[QString::fromLatin1("pt")] = QString::fromUtf8("Português");
+        languageNames[QString::fromLatin1("ro")] = QString::fromUtf8("Română");
+        languageNames[QString::fromLatin1("ru")] = QString::fromUtf8("Pусский");
+        languageNames[QString::fromLatin1("th")] = QString::fromUtf8("ภาษาไทย");
+        languageNames[QString::fromLatin1("tl")] = QString::fromUtf8("Tagalog");
+        languageNames[QString::fromLatin1("uk")] = QString::fromUtf8("Українська");
+        languageNames[QString::fromLatin1("vi")] = QString::fromUtf8("Tiếng Việt");
+        languageNames[QString::fromLatin1("zh_CN")] = QString::fromUtf8("简体中文");
+        languageNames[QString::fromLatin1("zh_TW")] = QString::fromUtf8("中文繁體");
 
 
         // Currently unsupported
-        // languageNames[QString::fromAscii("mi")] = QString::fromUtf8("Māori");
-        // languageNames[QString::fromAscii("ca")] = QString::fromUtf8("Català");
-        // languageNames[QString::fromAscii("eu")] = QString::fromUtf8("Euskara");
-        // languageNames[QString::fromAscii("af")] = QString::fromUtf8("Afrikaans");
-        // languageNames[QString::fromAscii("no")] = QString::fromUtf8("Norsk");
-        // languageNames[QString::fromAscii("bs")] = QString::fromUtf8("Bosanski");
-        // languageNames[QString::fromAscii("da")] = QString::fromUtf8("Dansk");
-        // languageNames[QString::fromAscii("el")] = QString::fromUtf8("ελληνικά");
-        // languageNames[QString::fromAscii("lt")] = QString::fromUtf8("Lietuvos");
-        // languageNames[QString::fromAscii("lv")] = QString::fromUtf8("Latviešu");
-        // languageNames[QString::fromAscii("mk")] = QString::fromUtf8("македонски");
-        // languageNames[QString::fromAscii("hi")] = QString::fromUtf8("हिंदी");
-        // languageNames[QString::fromAscii("ms")] = QString::fromUtf8("Bahasa Malaysia");
-        // languageNames[QString::fromAscii("cy")] = QString::fromUtf8("Cymraeg");
-        // languageNames[QString::fromAscii("ee")] = QString::fromUtf8("Eesti");
-        // languageNames[QString::fromAscii("fa")] = QString::fromUtf8("فارسی");
-        // languageNames[QString::fromAscii("hr")] = QString::fromUtf8("Hrvatski");
-        // languageNames[QString::fromAscii("ka")] = QString::fromUtf8("ქართული");
-        // languageNames[QString::fromAscii("cs")] = QString::fromUtf8("Čeština");
-        // languageNames[QString::fromAscii("sk")] = QString::fromUtf8("Slovenský");
-        // languageNames[QString::fromAscii("sl")] = QString::fromUtf8("Slovenščina");
-        // languageNames[QString::fromAscii("hu")] = QString::fromUtf8("Magyar");
-        // languageNames[QString::fromAscii("fi")] = QString::fromUtf8("Suomi");
-        // languageNames[QString::fromAscii("sr")] = QString::fromUtf8("српски");
-        // languageNames[QString::fromAscii("sv")] = QString::fromUtf8("Svenska");
-        // languageNames[QString::fromAscii("bg")] = QString::fromUtf8("български");
-        // languageNames[QString::fromAscii("he")] = QString::fromUtf8("עברית");
-        // languageNames[QString::fromAscii("tr")] = QString::fromUtf8("Türkçe");
+        // languageNames[QString::fromLatin1("mi")] = QString::fromUtf8("Māori");
+        // languageNames[QString::fromLatin1("ca")] = QString::fromUtf8("Català");
+        // languageNames[QString::fromLatin1("eu")] = QString::fromUtf8("Euskara");
+        // languageNames[QString::fromLatin1("af")] = QString::fromUtf8("Afrikaans");
+        // languageNames[QString::fromLatin1("no")] = QString::fromUtf8("Norsk");
+        // languageNames[QString::fromLatin1("bs")] = QString::fromUtf8("Bosanski");
+        // languageNames[QString::fromLatin1("da")] = QString::fromUtf8("Dansk");
+        // languageNames[QString::fromLatin1("el")] = QString::fromUtf8("ελληνικά");
+        // languageNames[QString::fromLatin1("lt")] = QString::fromUtf8("Lietuvos");
+        // languageNames[QString::fromLatin1("lv")] = QString::fromUtf8("Latviešu");
+        // languageNames[QString::fromLatin1("mk")] = QString::fromUtf8("македонски");
+        // languageNames[QString::fromLatin1("hi")] = QString::fromUtf8("हिंदी");
+        // languageNames[QString::fromLatin1("ms")] = QString::fromUtf8("Bahasa Malaysia");
+        // languageNames[QString::fromLatin1("cy")] = QString::fromUtf8("Cymraeg");
+        // languageNames[QString::fromLatin1("ee")] = QString::fromUtf8("Eesti");
+        // languageNames[QString::fromLatin1("fa")] = QString::fromUtf8("فارسی");
+        // languageNames[QString::fromLatin1("hr")] = QString::fromUtf8("Hrvatski");
+        // languageNames[QString::fromLatin1("ka")] = QString::fromUtf8("ქართული");
+        // languageNames[QString::fromLatin1("cs")] = QString::fromUtf8("Čeština");
+        // languageNames[QString::fromLatin1("sk")] = QString::fromUtf8("Slovenský");
+        // languageNames[QString::fromLatin1("sl")] = QString::fromUtf8("Slovenščina");
+        // languageNames[QString::fromLatin1("hu")] = QString::fromUtf8("Magyar");
+        // languageNames[QString::fromLatin1("fi")] = QString::fromUtf8("Suomi");
+        // languageNames[QString::fromLatin1("sr")] = QString::fromUtf8("српски");
+        // languageNames[QString::fromLatin1("sv")] = QString::fromUtf8("Svenska");
+        // languageNames[QString::fromLatin1("bg")] = QString::fromUtf8("български");
+        // languageNames[QString::fromLatin1("he")] = QString::fromUtf8("עברית");
+        // languageNames[QString::fromLatin1("tr")] = QString::fromUtf8("Türkçe");
 
     }
     return languageNames.value(code);
@@ -247,12 +247,12 @@ QString Utilities::languageCodeToString(QString code)
 
 QString Utilities::getExtensionPixmapSmall(QString fileName)
 {
-    return getExtensionPixmap(fileName, QString::fromAscii(":/images/small_"));
+    return getExtensionPixmap(fileName, QString::fromLatin1(":/images/small_"));
 }
 
 QString Utilities::getExtensionPixmapMedium(QString fileName)
 {
-    return getExtensionPixmap(fileName, QString::fromAscii(":/images/drag_"));
+    return getExtensionPixmap(fileName, QString::fromLatin1(":/images/drag_"));
 }
 
 QString Utilities::getAvatarPath(QString email)
@@ -320,7 +320,7 @@ void Utilities::copyRecursively(QString srcPath, QString dstPath)
     else if (source.isDir())
     {
         QDir dstDir(dstPath);
-        dstDir.mkpath(QString::fromAscii("."));
+        dstDir.mkpath(QString::fromLatin1("."));
         QDirIterator di(srcPath, QDir::AllEntries | QDir::Hidden | QDir::NoDotAndDotDot);
         while (di.hasNext())
         {
@@ -336,7 +336,7 @@ void Utilities::copyRecursively(QString srcPath, QString dstPath)
 bool Utilities::verifySyncedFolderLimits(QString path)
 {
 #ifdef WIN32
-    if (path.startsWith(QString::fromAscii("\\\\?\\")))
+    if (path.startsWith(QString::fromLatin1("\\\\?\\")))
     {
         path = path.mid(4);
     }
@@ -480,25 +480,25 @@ QString Utilities::getSizeString(unsigned long long bytes)
     QLocale locale(language);
     if (bytes >= TB)
     {
-        return locale.toString( ((int)((100 * bytes) / TB))/100.0) + QString::fromAscii(" ") + QCoreApplication::translate("Utilities", "TB");
+        return locale.toString( ((int)((100 * bytes) / TB))/100.0) + QString::fromLatin1(" ") + QCoreApplication::translate("Utilities", "TB");
     }
 
     if (bytes >= GB)
     {
-        return locale.toString( ((int)((100 * bytes) / GB))/100.0) + QString::fromAscii(" ") + QCoreApplication::translate("Utilities", "GB");
+        return locale.toString( ((int)((100 * bytes) / GB))/100.0) + QString::fromLatin1(" ") + QCoreApplication::translate("Utilities", "GB");
     }
 
     if (bytes >= MB)
     {
-        return locale.toString( ((int)((100 * bytes) / MB))/100.0) + QString::fromAscii(" ") + QCoreApplication::translate("Utilities", "MB");
+        return locale.toString( ((int)((100 * bytes) / MB))/100.0) + QString::fromLatin1(" ") + QCoreApplication::translate("Utilities", "MB");
     }
 
     if (bytes >= KB)
     {
-        return locale.toString( ((int)((100 * bytes) / KB))/100.0) + QString::fromAscii(" ") + QCoreApplication::translate("Utilities", "KB");
+        return locale.toString( ((int)((100 * bytes) / KB))/100.0) + QString::fromLatin1(" ") + QCoreApplication::translate("Utilities", "KB");
     }
 
-    return locale.toString(bytes) + QString::fromAscii(" bytes");
+    return locale.toString(bytes) + QString::fromLatin1(" bytes");
 }
 
 QString Utilities::extractJSONString(QString json, QString name)

--- a/src/MEGASync/gui/AccountDetailsDialog.cpp
+++ b/src/MEGASync/gui/AccountDetailsDialog.cpp
@@ -74,7 +74,7 @@ void AccountDetailsDialog::refresh(Preferences *preferences)
         ui->pUsageStorage->style()->polish(ui->pUsageStorage);
 
         QString used = tr("%1 of %2").arg(QString::fromUtf8("<span style=\"color:#333333; font-size: 18px; text-decoration:none;\">%1&nbsp;</span>")
-                                     .arg(QString::number(percentage > 100 ? 100 : percentage).append(QString::fromAscii(" %"))))
+                                     .arg(QString::number(percentage > 100 ? 100 : percentage).append(QString::fromLatin1(" %"))))
                                      .arg(QString::fromUtf8("<span style=\"color:#333333; font-size: 18px; text-decoration:none;\">&nbsp;%1</span>")
                                      .arg(Utilities::getSizeString(preferences->totalStorage())));
         ui->lPercentageUsedStorage->setText(used);

--- a/src/MEGASync/gui/ActiveTransfersWidget.cpp
+++ b/src/MEGASync/gui/ActiveTransfersWidget.cpp
@@ -30,7 +30,7 @@ ActiveTransfersWidget::ActiveTransfersWidget(QWidget *parent) :
     ui->sDownloads->setCurrentWidget(ui->wNoDownloads);
     ui->sUploads->setCurrentWidget(ui->wNoUploads);
     ui->sTransfersContainer->setCurrentWidget(ui->pNoTransfers);
-    ui->bGraphsSeparator->setStyleSheet(QString::fromAscii("background-color: transparent; "
+    ui->bGraphsSeparator->setStyleSheet(QString::fromLatin1("background-color: transparent; "
                                                            "border: none; "));
 }
 
@@ -473,7 +473,7 @@ void ActiveTransfersWidget::udpateTransferState(TransferData *td)
             }
             else
             {
-                remainingTime = QString::fromAscii("");
+                remainingTime = QString::fromLatin1("");
             }          
 
             break;
@@ -541,13 +541,13 @@ void ActiveTransfersWidget::updateNumberOfTransfers(mega::MegaApi *api)
     if (!totalDownloads && !totalUploads)
     {
         ui->sTransfersContainer->setCurrentWidget(ui->pNoTransfers);
-        ui->bGraphsSeparator->setStyleSheet(QString::fromAscii("background-color: transparent; "
+        ui->bGraphsSeparator->setStyleSheet(QString::fromLatin1("background-color: transparent; "
                                                                "border: none; "));
     }
     else
     {
         ui->sTransfersContainer->setCurrentWidget(ui->pTransfers);
-        ui->bGraphsSeparator->setStyleSheet(QString::fromAscii("background-color: rgba(0, 0, 0, 10%); "
+        ui->bGraphsSeparator->setStyleSheet(QString::fromLatin1("background-color: rgba(0, 0, 0, 10%); "
                                                                "border: none; "));
     }
 }

--- a/src/MEGASync/gui/BindFolderDialog.cpp
+++ b/src/MEGASync/gui/BindFolderDialog.cpp
@@ -137,14 +137,14 @@ void BindFolderDialog::on_bOK_clicked()
             QString p = QString::fromUtf8(nPath);
             delete [] nPath;
 
-            if (megaPath.startsWith(p) && ((p.size() == megaPath.size()) || p.size() == 1 || megaPath[p.size()] == QChar::fromAscii('/')))
+            if (megaPath.startsWith(p) && ((p.size() == megaPath.size()) || p.size() == 1 || megaPath[p.size()] == QChar::fromLatin1('/')))
             {
                 delete n;
                 delete node;
                 QMessageBox::warning(NULL, tr("Error"), tr("The selected MEGA folder is already synced"), QMessageBox::Ok);
                 return;
             }
-            else if (p.startsWith(megaPath) && ((p.size() == megaPath.size()) || megaPath.size() == 1 || p[megaPath.size()] == QChar::fromAscii('/')))
+            else if (p.startsWith(megaPath) && ((p.size() == megaPath.size()) || megaPath.size() == 1 || p[megaPath.size()] == QChar::fromLatin1('/')))
             {
                 delete n;
                 delete node;

--- a/src/MEGASync/gui/ChangeLogDialog.cpp
+++ b/src/MEGASync/gui/ChangeLogDialog.cpp
@@ -40,7 +40,7 @@ ChangeLogDialog::ChangeLogDialog(QString version, QString SDKversion, QString ch
     ui->lCopyright->setText(ui->lCopyright->text().arg(QDate::currentDate().year()));
     ui->tChangelog->document()->setDocumentMargin(16.0);
     ui->lVersion->setText(version);
-    ui->lSDKVersion->setText(QString::fromAscii(" (") + SDKversion + QString::fromAscii(")"));
+    ui->lSDKVersion->setText(QString::fromLatin1(" (") + SDKversion + QString::fromLatin1(")"));
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
     setChangeLogNotes(changeLog);
     highDpiResize.init(this);
@@ -64,25 +64,25 @@ void ChangeLogDialog::setChangeLogNotes(QString notes)
 
 void ChangeLogDialog::on_bTerms_clicked()
 {
-    QString temsUrl = Preferences::BASE_URL + QString::fromAscii("/terms");
+    QString temsUrl = Preferences::BASE_URL + QString::fromLatin1("/terms");
     QtConcurrent::run(QDesktopServices::openUrl, QUrl(temsUrl));
 }
 
 void ChangeLogDialog::on_bPolicy_clicked()
 {
-    QString policyUrl = Preferences::BASE_URL + QString::fromAscii("/privacy");
+    QString policyUrl = Preferences::BASE_URL + QString::fromLatin1("/privacy");
     QtConcurrent::run(QDesktopServices::openUrl, QUrl(policyUrl));
 }
 
 void ChangeLogDialog::on_bAck_clicked()
 {
-    QString ackUrl = QString::fromAscii("https://github.com/meganz/MEGAsync/blob/master/CREDITS.md");
+    QString ackUrl = QString::fromLatin1("https://github.com/meganz/MEGAsync/blob/master/CREDITS.md");
     QtConcurrent::run(QDesktopServices::openUrl, QUrl(ackUrl));
 }
 
 void ChangeLogDialog::on_bGDPR_clicked()
 {
-    QString gdprUrl = Preferences::BASE_URL + QString::fromAscii("/gdpr");
+    QString gdprUrl = Preferences::BASE_URL + QString::fromLatin1("/gdpr");
     QtConcurrent::run(QDesktopServices::openUrl, QUrl(gdprUrl));
 }
 

--- a/src/MEGASync/gui/CustomTransferItem.cpp
+++ b/src/MEGASync/gui/CustomTransferItem.cpp
@@ -180,7 +180,7 @@ void CustomTransferItem::finishTransfer()
     ui->sTransferState->setCurrentWidget(ui->completedTransfer);
     if (transferError < 0)
     {
-        ui->lGetLink->setIcon(QIcon(QString::fromAscii("://images/ico_item_retry.png")));
+        ui->lGetLink->setIcon(QIcon(QString::fromLatin1("://images/ico_item_retry.png")));
         ui->lGetLink->setIconSize(QSize(24,24));
         ui->lElapsedTime->setStyleSheet(QString::fromUtf8("color: #F0373A"));
         ui->lElapsedTime->setText(tr("failed:") + QString::fromUtf8(" ") + QCoreApplication::translate("MegaError", MegaError::getErrorString(transferError, this->getType() == MegaTransfer::TYPE_DOWNLOAD ? MegaError::API_EC_DOWNLOAD : MegaError::API_EC_DEFAULT)));
@@ -260,7 +260,7 @@ void CustomTransferItem::updateTransfer()
             }
             else
             {
-                remainingTime = QString::fromAscii("");
+                remainingTime = QString::fromLatin1("");
                 ui->bClockDown->setVisible(false);
             }
             ui->lRemainingTime->setText(remainingTime);
@@ -339,7 +339,7 @@ void CustomTransferItem::updateFinishedTime()
     QDateTime now = QDateTime::currentDateTime();
     qint64 secs = ( now.toMSecsSinceEpoch() / 100 - (preferences->getMsDiffTimeWithSDK() + dsFinishedTime) ) / 10;
 
-    ui->lGetLink->setIcon(QIcon(QString::fromAscii("://images/ico_item_link.png")));
+    ui->lGetLink->setIcon(QIcon(QString::fromLatin1("://images/ico_item_link.png")));
     ui->lGetLink->setIconSize(QSize(24,24));
     ui->lElapsedTime->setStyleSheet(QString::fromUtf8("color: #999999"));
     ui->lElapsedTime->setText(tr("Added [A]").replace(QString::fromUtf8("[A]"), Utilities::getFinishedTimeString(secs)));

--- a/src/MEGASync/gui/FolderBinder.cpp
+++ b/src/MEGASync/gui/FolderBinder.cpp
@@ -101,7 +101,7 @@ void FolderBinder::on_bLocalFolder_clicked()
     if (path.length())
     {        
         QDir dir(path);
-        if (!dir.exists() && !dir.mkpath(QString::fromAscii(".")))
+        if (!dir.exists() && !dir.mkpath(QString::fromLatin1(".")))
         {
             return;
         }

--- a/src/MEGASync/gui/GuestWidget.cpp
+++ b/src/MEGASync/gui/GuestWidget.cpp
@@ -19,8 +19,8 @@ GuestWidget::GuestWidget(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    ui->lEmail->setStyleSheet(QString::fromAscii("QLineEdit {color: black;}"));
-    ui->lPassword->setStyleSheet(QString::fromAscii("QLineEdit {color: black;}"));
+    ui->lEmail->setStyleSheet(QString::fromLatin1("QLineEdit {color: black;}"));
+    ui->lPassword->setStyleSheet(QString::fromLatin1("QLineEdit {color: black;}"));
 
     app = (MegaApplication *)qApp;
     megaApi = app->getMegaApi();
@@ -320,7 +320,7 @@ void GuestWidget::on_bLogin_clicked()
         return;
     }
 
-    if (!email.contains(QChar::fromAscii('@')) || !email.contains(QChar::fromAscii('.')))
+    if (!email.contains(QChar::fromLatin1('@')) || !email.contains(QChar::fromLatin1('.')))
     {
         QMessageBox::warning(NULL, tr("Error"), tr("Please, enter a valid e-mail address"), QMessageBox::Ok);
         return;

--- a/src/MEGASync/gui/ImportListWidgetItem.cpp
+++ b/src/MEGASync/gui/ImportListWidgetItem.cpp
@@ -38,7 +38,7 @@ void ImportListWidgetItem::updateGui()
     QString name;
     if (fileSize)
     {
-        name = fileName + QString::fromAscii(" (") + Utilities::getSizeString(fileSize) + QString::fromAscii(")");
+        name = fileName + QString::fromLatin1(" (") + Utilities::getSizeString(fileSize) + QString::fromLatin1(")");
     }
     else
     {

--- a/src/MEGASync/gui/ImportMegaLinksDialog.cpp
+++ b/src/MEGASync/gui/ImportMegaLinksDialog.cpp
@@ -53,7 +53,7 @@ ImportMegaLinksDialog::ImportMegaLinksDialog(MegaApi *megaApi, Preferences *pref
     if (!test.isDir())
     {
         QDir defaultFolder(QDir::toNativeSeparators(Utilities::getDefaultBasePath() + QString::fromUtf8("/MEGAsync Downloads")));
-        defaultFolder.mkpath(QString::fromAscii("."));
+        defaultFolder.mkpath(QString::fromLatin1("."));
         defaultFolderPath = defaultFolder.absolutePath();
         defaultFolderPath = QDir::toNativeSeparators(defaultFolderPath);
     }
@@ -217,7 +217,7 @@ void ImportMegaLinksDialog::on_bLocalFolder_clicked()
     {
         path = QDir::toNativeSeparators(path);
         QDir dir(path);
-        if (!dir.exists() && !dir.mkpath(QString::fromAscii(".")))
+        if (!dir.exists() && !dir.mkpath(QString::fromLatin1(".")))
         {
             return;
         }
@@ -274,7 +274,7 @@ void ImportMegaLinksDialog::onLinkInfoAvailable(int id)
     if (node && (e == MegaError::API_OK))
     {
         QString name = QString::fromUtf8(node->getName());
-        if (!name.compare(QString::fromAscii("NO_KEY")) || !name.compare(QString::fromAscii("CRYPTO_ERROR")))
+        if (!name.compare(QString::fromLatin1("NO_KEY")) || !name.compare(QString::fromLatin1("CRYPTO_ERROR")))
         {
             item->setData(tr("Decryption error"), ImportListWidgetItem::WARNING, megaApi->getSize(node), !(node->getType() == MegaNode::TYPE_FILE));
         }

--- a/src/MEGASync/gui/InfoDialog.cpp
+++ b/src/MEGASync/gui/InfoDialog.cpp
@@ -141,9 +141,9 @@ InfoDialog::InfoDialog(MegaApplication *app, QWidget *parent, InfoDialog* olddia
 
 #ifdef __APPLE__
     arrow = new QPushButton(this);
-    arrow->setIcon(QIcon(QString::fromAscii("://images/top_arrow.png")));
+    arrow->setIcon(QIcon(QString::fromLatin1("://images/top_arrow.png")));
     arrow->setIconSize(QSize(30,10));
-    arrow->setStyleSheet(QString::fromAscii("border: none;"));
+    arrow->setStyleSheet(QString::fromLatin1("border: none;"));
     arrow->resize(30,10);
     arrow->hide();
 
@@ -155,7 +155,7 @@ InfoDialog::InfoDialog(MegaApplication *app, QWidget *parent, InfoDialog* olddia
     //Create the overlay widget with a semi-transparent background
     //that will be shown over the transfers when they are paused
     overlay = new QPushButton(this);
-    overlay->setStyleSheet(QString::fromAscii("background-color: transparent; "
+    overlay->setStyleSheet(QString::fromLatin1("background-color: transparent; "
                                               "border: none; "));
     overlay->resize(ui->pUpdated->size());
     overlay->setCursor(Qt::PointingHandCursor);
@@ -296,7 +296,7 @@ void InfoDialog::setUsage()
         ui->pUsageStorage->style()->polish(ui->pUsageStorage);
 
         QString used = tr("%1 of %2").arg(QString::fromUtf8("<span style=\"color:#333333; font-size: 16px; text-decoration:none;\">%1</span>")
-                                     .arg(QString::number(percentage > 100 ? 100 : percentage).append(QString::fromAscii("%"))))
+                                     .arg(QString::number(percentage > 100 ? 100 : percentage).append(QString::fromLatin1("%"))))
                                      .arg(QString::fromUtf8("<span style=\"color:#333333; font-size: 16px; text-decoration:none;\">&nbsp;%1</span>")
                                      .arg(Utilities::getSizeString(preferences->totalStorage())));
         ui->lPercentageUsedStorage->setText(used);
@@ -326,7 +326,7 @@ void InfoDialog::setUsage()
         ui->pUsageQuota->style()->polish(ui->pUsageQuota);
 
         QString used = tr("%1 of %2").arg(QString::fromUtf8("<span style=\"color:#333333; font-size: 16px; text-decoration:none;\">%1&nbsp;</span>")
-                                     .arg(QString::number(percentage > 100 ? 100 : percentage).append(QString::fromAscii("%"))))
+                                     .arg(QString::number(percentage > 100 ? 100 : percentage).append(QString::fromLatin1("%"))))
                                      .arg(QString::fromUtf8("<span style=\"color:#333333; font-size: 16px; text-decoration:none;\">&nbsp;%1</span>")
                                      .arg(Utilities::getSizeString(preferences->totalBandwidth())));
         ui->lPercentageUsedQuota->setText(used);
@@ -429,7 +429,7 @@ void InfoDialog::updateSyncsButton()
     MegaNode *rootNode = megaApi->getRootNode();
     if (!rootNode)
     {
-        ui->bSyncFolder->setText(QString::fromAscii("MEGA"));
+        ui->bSyncFolder->setText(QString::fromLatin1("MEGA"));
         return;
     }
 
@@ -712,7 +712,7 @@ void InfoDialog::updateDialogState()
     switch (storageState)
     {
         case Preferences::STATE_ALMOST_OVER_STORAGE:
-            ui->bOQIcon->setIcon(QIcon(QString::fromAscii("://images/storage_almost_full.png")));
+            ui->bOQIcon->setIcon(QIcon(QString::fromLatin1("://images/storage_almost_full.png")));
             ui->bOQIcon->setIconSize(QSize(64,64));
             ui->lOQTitle->setText(tr("You're running out of storage space."));
             ui->lOQDesc->setText(tr("Upgrade to PRO now before your account runs full and your uploads to MEGA stop."));
@@ -721,7 +721,7 @@ void InfoDialog::updateDialogState()
             ui->wPSA->hidePSA();
             break;
         case Preferences::STATE_OVER_STORAGE:
-            ui->bOQIcon->setIcon(QIcon(QString::fromAscii("://images/storage_full.png")));
+            ui->bOQIcon->setIcon(QIcon(QString::fromLatin1("://images/storage_full.png")));
             ui->bOQIcon->setIconSize(QSize(64,64));
             ui->lOQTitle->setText(tr("Your MEGA account is full."));
             ui->lOQDesc->setText(tr("All file uploads are currently disabled.")
@@ -839,9 +839,9 @@ void InfoDialog::on_bSyncFolder_clicked()
         syncsMenu.reset(new QMenu());
 
 #ifdef __APPLE__
-        syncsMenu->setStyleSheet(QString::fromAscii("QMenu {background: #ffffff; padding-top: 8px; padding-bottom: 8px;}"));
+        syncsMenu->setStyleSheet(QString::fromLatin1("QMenu {background: #ffffff; padding-top: 8px; padding-bottom: 8px;}"));
 #else
-        syncsMenu->setStyleSheet(QString::fromAscii("QMenu { border: 1px solid #B8B8B8; border-radius: 5px; background: #ffffff; padding-top: 8px; padding-bottom: 8px;}"));
+        syncsMenu->setStyleSheet(QString::fromLatin1("QMenu { border: 1px solid #B8B8B8; border-radius: 5px; background: #ffffff; padding-top: 8px; padding-bottom: 8px;}"));
 #endif
         if (menuSignalMapper)
         {
@@ -861,8 +861,8 @@ void InfoDialog::on_bSyncFolder_clicked()
             }
 
             activeFolders++;
-            MenuItemAction *action = new MenuItemAction(preferences->getSyncName(i), QIcon(QString::fromAscii("://images/ico_drop_synched_folder.png")),
-                                                        QIcon(QString::fromAscii("://images/ico_drop_synched_folder_over.png")));
+            MenuItemAction *action = new MenuItemAction(preferences->getSyncName(i), QIcon(QString::fromLatin1("://images/ico_drop_synched_folder.png")),
+                                                        QIcon(QString::fromLatin1("://images/ico_drop_synched_folder_over.png")));
             connect(action, SIGNAL(triggered()), menuSignalMapper, SLOT(map()));
             syncsMenu->addAction(action);
             menuSignalMapper->setMapping(action, preferences->getLocalFolder(i));
@@ -881,8 +881,8 @@ void InfoDialog::on_bSyncFolder_clicked()
                 long long rootHandle = rootNode->getHandle();
                 if ((num > 1) || (firstSyncHandle != rootHandle))
                 {
-                    MenuItemAction *addSyncAction = new MenuItemAction(tr("Add Sync"), QIcon(QString::fromAscii("://images/ico_add_sync.png")),
-                                                                       QIcon(QString::fromAscii("://images/ico_drop_add_sync_over.png")));
+                    MenuItemAction *addSyncAction = new MenuItemAction(tr("Add Sync"), QIcon(QString::fromLatin1("://images/ico_add_sync.png")),
+                                                                       QIcon(QString::fromLatin1("://images/ico_drop_add_sync_over.png")));
                     connect(addSyncAction, SIGNAL(triggered()), this, SLOT(addSync()), Qt::QueuedConnection);
 
                     if (activeFolders)
@@ -1259,7 +1259,7 @@ void InfoDialog::animateStates(bool opt)
 {
     if (opt) //Enable animation for scanning/waiting states
     {        
-        ui->lUploadToMega->setIcon(QIcon(QString::fromAscii("://images/init_scanning.png")));
+        ui->lUploadToMega->setIcon(QIcon(QString::fromLatin1("://images/init_scanning.png")));
         ui->lUploadToMega->setIconSize(QSize(352,234));
         ui->lUploadToMegaDesc->setStyleSheet(QString::fromUtf8("font-size: 14px;"));
 
@@ -1286,7 +1286,7 @@ void InfoDialog::animateStates(bool opt)
     }
     else //Disable animation
     {   
-        ui->lUploadToMega->setIcon(QIcon(QString::fromAscii("://images/upload_to_mega.png")));
+        ui->lUploadToMega->setIcon(QIcon(QString::fromLatin1("://images/upload_to_mega.png")));
         ui->lUploadToMega->setIconSize(QSize(352,234));
         ui->lUploadToMegaDesc->setStyleSheet(QString::fromUtf8("font-size: 18px;"));
         ui->lUploadToMegaDesc->setText(tr("Upload to MEGA now"));
@@ -1313,9 +1313,9 @@ void InfoDialog::onUserAction(int action)
 
 void InfoDialog::on_bDotUsedStorage_clicked()
 {
-    ui->bDotUsedStorage->setIcon(QIcon(QString::fromAscii("://images/Nav_Dot_active.png")));
+    ui->bDotUsedStorage->setIcon(QIcon(QString::fromLatin1("://images/Nav_Dot_active.png")));
     ui->bDotUsedStorage->setIconSize(QSize(6,6));
-    ui->bDotUsedQuota->setIcon(QIcon(QString::fromAscii("://images/Nav_Dot_inactive.png")));
+    ui->bDotUsedQuota->setIcon(QIcon(QString::fromLatin1("://images/Nav_Dot_inactive.png")));
     ui->bDotUsedQuota->setIconSize(QSize(6,6));
 
     ui->sUsedData->setCurrentWidget(ui->pStorage);
@@ -1323,9 +1323,9 @@ void InfoDialog::on_bDotUsedStorage_clicked()
 
 void InfoDialog::on_bDotUsedQuota_clicked()
 {
-    ui->bDotUsedStorage->setIcon(QIcon(QString::fromAscii("://images/Nav_Dot_inactive.png")));
+    ui->bDotUsedStorage->setIcon(QIcon(QString::fromLatin1("://images/Nav_Dot_inactive.png")));
     ui->bDotUsedStorage->setIconSize(QSize(6,6));
-    ui->bDotUsedQuota->setIcon(QIcon(QString::fromAscii("://images/Nav_Dot_active.png")));
+    ui->bDotUsedQuota->setIcon(QIcon(QString::fromLatin1("://images/Nav_Dot_active.png")));
     ui->bDotUsedQuota->setIconSize(QSize(6,6));
 
     ui->sUsedData->setCurrentWidget(ui->pQuota);

--- a/src/MEGASync/gui/InfoWizard.cpp
+++ b/src/MEGASync/gui/InfoWizard.cpp
@@ -122,13 +122,13 @@ void InfoWizard::goToPage(int page)
 
 void InfoWizard::selectedBullet(QPushButton *b)
 {
-    ui->bFirstBullet->setIcon(QIcon(QString::fromAscii("://images/icon_slice_dot.png")));
+    ui->bFirstBullet->setIcon(QIcon(QString::fromLatin1("://images/icon_slice_dot.png")));
     ui->bFirstBullet->setIconSize(QSize(6,6));
-    ui->bSecondBullet->setIcon(QIcon(QString::fromAscii("://images/icon_slice_dot.png")));
+    ui->bSecondBullet->setIcon(QIcon(QString::fromLatin1("://images/icon_slice_dot.png")));
     ui->bSecondBullet->setIconSize(QSize(6,6));
-    ui->bThirdBullet->setIcon(QIcon(QString::fromAscii("://images/icon_slice_dot.png")));
+    ui->bThirdBullet->setIcon(QIcon(QString::fromLatin1("://images/icon_slice_dot.png")));
     ui->bThirdBullet->setIconSize(QSize(6,6));
 
-    b->setIcon(QIcon(QString::fromAscii("://images/icon_slice_dot_selected.png")));
+    b->setIcon(QIcon(QString::fromLatin1("://images/icon_slice_dot_selected.png")));
     b->setIconSize(QSize(6,6));
 }

--- a/src/MEGASync/gui/LocalCleanScheduler.cpp
+++ b/src/MEGASync/gui/LocalCleanScheduler.cpp
@@ -9,7 +9,7 @@ LocalCleanScheduler::LocalCleanScheduler(QWidget *parent) :
     ui->setupUi(this);
     setAttribute(Qt::WA_QuitOnClose, false);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
-    setWindowTitle(windowTitle().arg(QString::fromAscii(mega::MEGA_DEBRIS_FOLDER)));
+    setWindowTitle(windowTitle().arg(QString::fromLatin1(mega::MEGA_DEBRIS_FOLDER)));
 
     ui->eNumberDays->setMaximum(365);
     ui->bOK->setDefault(true);
@@ -45,7 +45,7 @@ void LocalCleanScheduler::changeEvent(QEvent *event)
 {
     if (event->type() == QEvent::LanguageChange)
     {
-        setWindowTitle(windowTitle().arg(QString::fromAscii(mega::MEGA_DEBRIS_FOLDER)));
+        setWindowTitle(windowTitle().arg(QString::fromLatin1(mega::MEGA_DEBRIS_FOLDER)));
         ui->retranslateUi(this);
     }
     QDialog::changeEvent(event);

--- a/src/MEGASync/gui/Login2FA.cpp
+++ b/src/MEGASync/gui/Login2FA.cpp
@@ -81,7 +81,7 @@ void Login2FA::inputCodeChanged()
 
 void Login2FA::on_bHelp_clicked()
 {
-    QString helpUrl = Preferences::BASE_URL + QString::fromAscii("/recovery");
+    QString helpUrl = Preferences::BASE_URL + QString::fromLatin1("/recovery");
     QtConcurrent::run(QDesktopServices::openUrl, QUrl(helpUrl));
 }
 

--- a/src/MEGASync/gui/MegaTransferDelegate.cpp
+++ b/src/MEGASync/gui/MegaTransferDelegate.cpp
@@ -276,7 +276,7 @@ bool MegaTransferDelegate::editorEvent(QEvent *event, QAbstractItemModel *, cons
             {
                 QString localPath = QString::fromUtf8(transfer->getPath());
                 #ifdef WIN32
-                if (localPath.startsWith(QString::fromAscii("\\\\?\\")))
+                if (localPath.startsWith(QString::fromLatin1("\\\\?\\")))
                 {
                     localPath = localPath.mid(4);
                 }
@@ -299,7 +299,7 @@ bool MegaTransferDelegate::editorEvent(QEvent *event, QAbstractItemModel *, cons
         {
             QString localPath = QString::fromUtf8(transfer->getPath());
             #ifdef WIN32
-            if (localPath.startsWith(QString::fromAscii("\\\\?\\")))
+            if (localPath.startsWith(QString::fromLatin1("\\\\?\\")))
             {
                 localPath = localPath.mid(4);
             }

--- a/src/MEGASync/gui/MegaTransferView.cpp
+++ b/src/MEGASync/gui/MegaTransferView.cpp
@@ -92,7 +92,7 @@ void MegaTransferView::createContextMenu()
     if (!contextInProgressMenu)
     {
         contextInProgressMenu = new QMenu(this);
-        contextInProgressMenu->setStyleSheet(QString::fromAscii(
+        contextInProgressMenu->setStyleSheet(QString::fromLatin1(
 #ifdef __APPLE__
                                    "QMenu {background: #ffffff;}"
 #else
@@ -197,7 +197,7 @@ void MegaTransferView::createCompletedContextMenu()
     if (!contextCompleted)
     {
         contextCompleted = new QMenu(this);
-        contextCompleted->setStyleSheet(QString::fromAscii(
+        contextCompleted->setStyleSheet(QString::fromLatin1(
                                    "QMenu {background: #ffffff;}"
 #if QT_VERSION < 0x050000
                                    "QMenu::item {font-family: Source Sans Pro; margin: 5px 9px 5px 9px; margin-right: 8px; color: #777777; padding: 5px 16px 5px 8px;} "
@@ -684,7 +684,7 @@ void MegaTransferView::showInFolderClicked()
             {
                 QString localPath = QString::fromUtf8(transfer->getPath());
                 #ifdef WIN32
-                if (localPath.startsWith(QString::fromAscii("\\\\?\\")))
+                if (localPath.startsWith(QString::fromLatin1("\\\\?\\")))
                 {
                     localPath = localPath.mid(4);
                 }
@@ -711,7 +711,7 @@ void MegaTransferView::showInMEGAClicked()
                 if (handle != INVALID_HANDLE)
                 {
                     const char *b64handle = MegaApi::handleToBase64(handle);
-                    QString url = Preferences::BASE_URL + QString::fromAscii("/fm/") + QString::fromUtf8(b64handle);
+                    QString url = Preferences::BASE_URL + QString::fromLatin1("/fm/") + QString::fromUtf8(b64handle);
                     QtConcurrent::run(QDesktopServices::openUrl, QUrl(url));
                     delete [] b64handle;
                 }

--- a/src/MEGASync/gui/MenuItemAction.cpp
+++ b/src/MEGASync/gui/MenuItemAction.cpp
@@ -84,15 +84,15 @@ void MenuItemAction::setHighlight(bool highlight)
     if (highlight)
     {
         container->setStyleSheet(QString::fromUtf8("#wContainer { border: 2px solid #aaaaaa; border-radius: 2px; margin: 0px 8px 0px 8px; padding: 0px; background-color: #aaaaaa; }"));
-        title->setStyleSheet(QString::fromAscii("font-family: Source Sans Pro; font-size: 14px; color: #ffffff;"));
-        iconButton->setStyleSheet(QString::fromAscii("border: none;"));
+        title->setStyleSheet(QString::fromLatin1("font-family: Source Sans Pro; font-size: 14px; color: #ffffff;"));
+        iconButton->setStyleSheet(QString::fromLatin1("border: none;"));
         hoverIcon ? iconButton->setIcon(*hoverIcon) : iconButton->setIcon(*icon);
     }
     else
     {
         container->setStyleSheet(QString::fromUtf8("#wContainer { border: none; margin: 0px 0px 0px 0px; padding: 0px; background-color: #ffffff; }"));
-        title->setStyleSheet(QString::fromAscii("font-family: Source Sans Pro; font-size: 14px; color: #777777;"));
-        iconButton->setStyleSheet(QString::fromAscii("border: none;"));
+        title->setStyleSheet(QString::fromLatin1("font-family: Source Sans Pro; font-size: 14px; color: #777777;"));
+        iconButton->setStyleSheet(QString::fromLatin1("border: none;"));
         iconButton->setIcon(*icon);
     }
 }
@@ -112,7 +112,7 @@ void MenuItemAction::setupActionWidget(QSize iconSize)
 {
     container->setMinimumHeight(32);
     container->setMaximumHeight(32);
-    container->setStyleSheet(QString::fromAscii("#wContainer { margin-left: 20px; padding: 0px; }"));
+    container->setStyleSheet(QString::fromLatin1("#wContainer { margin-left: 20px; padding: 0px; }"));
 
     iconButton = new QPushButton();
     iconButton->setAttribute(Qt::WA_TransparentForMouseEvents, true);
@@ -127,7 +127,7 @@ void MenuItemAction::setupActionWidget(QSize iconSize)
     iconButton->setIcon(*icon);
     iconButton->setFlat(true);
 
-    title->setStyleSheet(QString::fromAscii("font-family: Source Sans Pro; font-size: 14px; color: #777777;"));
+    title->setStyleSheet(QString::fromLatin1("font-family: Source Sans Pro; font-size: 14px; color: #777777;"));
 
     layout = new QHBoxLayout();
     layout->setContentsMargins(QMargins(16, 0, 8, 0));
@@ -138,7 +138,7 @@ void MenuItemAction::setupActionWidget(QSize iconSize)
 
     if (value)
     {
-        value->setStyleSheet(QString::fromAscii("font-family: Source Sans Pro; font-size: 14px; color: #777777; padding-right: 6px;"));
+        value->setStyleSheet(QString::fromLatin1("font-family: Source Sans Pro; font-size: 14px; color: #777777; padding-right: 6px;"));
         layout->addWidget(value);
     }
     container->setLayout(layout);
@@ -151,16 +151,16 @@ bool MenuItemAction::eventFilter(QObject *obj, QEvent *event)
         if (event->type() == QEvent::Enter)
         {
             container->setStyleSheet(QString::fromUtf8("#wContainer { border: 2px solid #aaaaaa; border-radius: 2px; margin: 0px 8px 0px 8px; padding: 0px; background-color: #aaaaaa; }"));
-            title->setStyleSheet(QString::fromAscii("font-family: Source Sans Pro; font-size: 14px; color: #ffffff;"));
-            iconButton->setStyleSheet(QString::fromAscii("border: none;"));
+            title->setStyleSheet(QString::fromLatin1("font-family: Source Sans Pro; font-size: 14px; color: #ffffff;"));
+            iconButton->setStyleSheet(QString::fromLatin1("border: none;"));
             hoverIcon ? iconButton->setIcon(*hoverIcon) : iconButton->setIcon(*icon);
         }
 
         if (event->type() == QEvent::Leave)
         {
             container->setStyleSheet(QString::fromUtf8("#wContainer { border: none; margin: 0px 0px 0px 0px; padding: 0px; background-color: #ffffff; }"));
-            title->setStyleSheet(QString::fromAscii("font-family: Source Sans Pro; font-size: 14px; color: #777777;"));
-            iconButton->setStyleSheet(QString::fromAscii("border: none;"));
+            title->setStyleSheet(QString::fromLatin1("font-family: Source Sans Pro; font-size: 14px; color: #777777;"));
+            iconButton->setStyleSheet(QString::fromLatin1("border: none;"));
             iconButton->setIcon(*icon);
         }
     }

--- a/src/MEGASync/gui/NodeSelector.cpp
+++ b/src/MEGASync/gui/NodeSelector.cpp
@@ -20,7 +20,7 @@ NodeSelector::NodeSelector(MegaApi *megaApi, int selectMode, QWidget *parent) :
 
     this->megaApi = megaApi;
     this->model = NULL;
-    folderIcon =  QIcon(QString::fromAscii("://images/small_folder.png"));
+    folderIcon =  QIcon(QString::fromLatin1("://images/small_folder.png"));
     selectedFolder = mega::INVALID_HANDLE;
     selectedItem = QModelIndex();
     this->selectMode = selectMode;

--- a/src/MEGASync/gui/PasteMegaLinksDialog.cpp
+++ b/src/MEGASync/gui/PasteMegaLinksDialog.cpp
@@ -78,28 +78,28 @@ QStringList PasteMegaLinksDialog::extractLinks(QString text)
     {
         QString linkHeader = linkHeaders[i];
 
-        QStringList tempLinks = text.split(QString::fromAscii("https://mega.co.nz/").append(linkHeader), QString::KeepEmptyParts, Qt::CaseInsensitive);
+        QStringList tempLinks = text.split(QString::fromLatin1("https://mega.co.nz/").append(linkHeader), QString::KeepEmptyParts, Qt::CaseInsensitive);
         tempLinks.removeAt(0);
 
-        QStringList tempLinks2 = text.split(QString::fromAscii("mega://").append(linkHeader), QString::KeepEmptyParts, Qt::CaseInsensitive);
+        QStringList tempLinks2 = text.split(QString::fromLatin1("mega://").append(linkHeader), QString::KeepEmptyParts, Qt::CaseInsensitive);
         tempLinks2.removeAt(0);
         tempLinks.append(tempLinks2);
 
-        QStringList tempLinksNewSite = text.split(QString::fromAscii("https://mega.nz/").append(linkHeader), QString::KeepEmptyParts, Qt::CaseInsensitive);
+        QStringList tempLinksNewSite = text.split(QString::fromLatin1("https://mega.nz/").append(linkHeader), QString::KeepEmptyParts, Qt::CaseInsensitive);
         tempLinksNewSite.removeAt(0);
         tempLinks.append(tempLinksNewSite);
 
-        QStringList tempLinksHttp = text.split(QString::fromAscii("http://mega.co.nz/").append(linkHeader), QString::KeepEmptyParts, Qt::CaseInsensitive);
+        QStringList tempLinksHttp = text.split(QString::fromLatin1("http://mega.co.nz/").append(linkHeader), QString::KeepEmptyParts, Qt::CaseInsensitive);
         tempLinksHttp.removeAt(0);
         tempLinks.append(tempLinksHttp);
 
-        QStringList tempLinksNewSiteHttp = text.split(QString::fromAscii("http://mega.nz/").append(linkHeader), QString::KeepEmptyParts, Qt::CaseInsensitive);
+        QStringList tempLinksNewSiteHttp = text.split(QString::fromLatin1("http://mega.nz/").append(linkHeader), QString::KeepEmptyParts, Qt::CaseInsensitive);
         tempLinksNewSiteHttp.removeAt(0);
         tempLinks.append(tempLinksNewSiteHttp);
 
         for (int i = 0; i < tempLinks.size(); i++)
         {
-            QString link = checkLink(tempLinks[i].insert(0, QString::fromAscii("https://mega.nz/").append(linkHeader)));
+            QString link = checkLink(tempLinks[i].insert(0, QString::fromLatin1("https://mega.nz/").append(linkHeader)));
             if (!link.isNull())
             {
                 finalLinks.append(link);
@@ -113,10 +113,10 @@ QStringList PasteMegaLinksDialog::extractLinks(QString text)
 QString PasteMegaLinksDialog::checkLink(QString link)
 {
     link = QUrl::fromPercentEncoding(link.toUtf8());
-    link.replace(QChar::fromAscii(' '), QChar::fromAscii('+'));
+    link.replace(QChar::fromLatin1(' '), QChar::fromLatin1('+'));
 
     // File link
-    if (link.at(26) == QChar::fromAscii('!'))
+    if (link.at(26) == QChar::fromLatin1('!'))
     {
         if (link.length() < FILE_LINK_SIZE)
         {
@@ -128,9 +128,9 @@ QString PasteMegaLinksDialog::checkLink(QString link)
     }
 
     // Folder link
-    if (link.at(27) == QChar::fromAscii('!'))
+    if (link.at(27) == QChar::fromLatin1('!'))
     {
-        if (link.length() >= FOLDER_LINK_WITH_SUBFOLDER_SIZE && link.count(QChar::fromAscii('!')) == 3)
+        if (link.length() >= FOLDER_LINK_WITH_SUBFOLDER_SIZE && link.count(QChar::fromLatin1('!')) == 3)
         {
             link.truncate(FOLDER_LINK_WITH_SUBFOLDER_SIZE);
         }

--- a/src/MEGASync/gui/PlanWidget.cpp
+++ b/src/MEGASync/gui/PlanWidget.cpp
@@ -27,7 +27,7 @@ PlanWidget::PlanWidget(PlanInfo data, QString userAgent, QWidget *parent) :
     //that will be shown over the Plans to manage clicked() events
     overlay = new QPushButton(this);
     overlay->setObjectName(QString::fromUtf8("bOverlay"));
-    overlay->setStyleSheet(QString::fromAscii(
+    overlay->setStyleSheet(QString::fromLatin1(
                                "QPushButton#bOverlay:hover {border-image: url(://images/account_type_over.png);} "
                                "QPushButton#bOverlay {border-radius: 3px; border: 1px solid; border-color: rgba(0, 0, 0, 0.1); border: none;} "
                                "QPushButton#bOverlay:pressed {border-image: url(://images/account_type_press.png);}"));
@@ -90,32 +90,32 @@ void PlanWidget::updatePlanInfo()
     switch (details.level)
     {
         case PRO_LITE:
-            ui->bcrest->setIcon(QIcon(QString::fromAscii("://images/litecrest.png")));
+            ui->bcrest->setIcon(QIcon(QString::fromLatin1("://images/litecrest.png")));
             ui->bcrest->setIconSize(QSize(64, 64));
             ui->lProPlan->setText(QString::fromUtf8("PRO LITE"));
             ui->lPeriod->setStyleSheet(QString::fromUtf8("color: #ffa500;"));
             break;
         case PRO_I:
             ui->lTip->setText(tr("popular!"));
-            ui->bcrest->setIcon(QIcon(QString::fromAscii("://images/proicrest.png")));
+            ui->bcrest->setIcon(QIcon(QString::fromLatin1("://images/proicrest.png")));
             ui->bcrest->setIconSize(QSize(64, 64));
             ui->lProPlan->setText(QString::fromUtf8("PRO I"));
             ui->lPeriod->setStyleSheet(QString::fromUtf8("color: #ff333a;"));
             break;
         case PRO_II:
-            ui->bcrest->setIcon(QIcon(QString::fromAscii("://images/proiicrest.png")));
+            ui->bcrest->setIcon(QIcon(QString::fromLatin1("://images/proiicrest.png")));
             ui->bcrest->setIconSize(QSize(64, 64));
             ui->lProPlan->setText(QString::fromUtf8("PRO II"));
             ui->lPeriod->setStyleSheet(QString::fromUtf8("color: #ff333a;"));
             break;
         case PRO_III:
-            ui->bcrest->setIcon(QIcon(QString::fromAscii("://images/proiiicrest.png")));
+            ui->bcrest->setIcon(QIcon(QString::fromLatin1("://images/proiiicrest.png")));
             ui->bcrest->setIconSize(QSize(64, 64));
             ui->lProPlan->setText(QString::fromUtf8("PRO III"));
             ui->lPeriod->setStyleSheet(QString::fromUtf8("color: #ff333a;"));
             break;
         default:
-            ui->bcrest->setIcon(QIcon(QString::fromAscii("://images/litecrest.png")));
+            ui->bcrest->setIcon(QIcon(QString::fromLatin1("://images/litecrest.png")));
             ui->bcrest->setIconSize(QSize(64, 64));
             ui->lProPlan->setText(QString::fromUtf8("PRO"));
             ui->lPeriod->setStyleSheet(QString::fromUtf8("color: #ffa500;"));

--- a/src/MEGASync/gui/QMegaModel.cpp
+++ b/src/MEGASync/gui/QMegaModel.cpp
@@ -12,7 +12,7 @@ QMegaModel::QMegaModel(mega::MegaApi *megaApi, QObject *parent) :
     this->megaApi = megaApi;
     this->root = megaApi->getRootNode();
     this->rootItem = new MegaItem(root);
-    this->folderIcon =  QIcon(QString::fromAscii("://images/small_folder.png"));
+    this->folderIcon =  QIcon(QString::fromLatin1("://images/small_folder.png"));
 
     MegaUserList *contacts = megaApi->getContacts();
     for (int i = 0; i < contacts->size(); i++)
@@ -62,11 +62,11 @@ QVariant QMegaModel::data(const QModelIndex &index, int role) const
             {
                 if (node->isInShare())
                 {
-                    return QIcon(QString::fromAscii("://images/small_folder_incoming.png"));;
+                    return QIcon(QString::fromLatin1("://images/small_folder_incoming.png"));;
                 }
                 else if (node->isOutShare())
                 {
-                    return QIcon(QString::fromAscii("://images/small_folder_outgoing.png"));;
+                    return QIcon(QString::fromLatin1("://images/small_folder_outgoing.png"));;
                 }
 
                 return folderIcon;

--- a/src/MEGASync/gui/SettingsDialog.cpp
+++ b/src/MEGASync/gui/SettingsDialog.cpp
@@ -41,7 +41,7 @@ long long calculateCacheSize()
         QString syncPath = preferences->getLocalFolder(i);
         if (!syncPath.isEmpty())
         {
-            Utilities::getFolderSize(syncPath + QDir::separator() + QString::fromAscii(MEGA_DEBRIS_FOLDER), &cacheSize);
+            Utilities::getFolderSize(syncPath + QDir::separator() + QString::fromLatin1(MEGA_DEBRIS_FOLDER), &cacheSize);
         }
     }
     return cacheSize;
@@ -251,7 +251,7 @@ SettingsDialog::SettingsDialog(MegaApplication *app, bool proxyOnly, QWidget *pa
     ui->bAdvanced->setStyleSheet(QString::fromUtf8("QToolButton:checked { border-image: url(\":/images/menu_selected.png\"); }"));
 #endif
 
-    ui->bLocalCleaner->setText(ui->bLocalCleaner->text().arg(QString::fromAscii(MEGA_DEBRIS_FOLDER)));
+    ui->bLocalCleaner->setText(ui->bLocalCleaner->text().arg(QString::fromLatin1(MEGA_DEBRIS_FOLDER)));
 
     ui->gCache->setVisible(false);
     ui->lFileVersionsSize->setVisible(false);
@@ -815,7 +815,7 @@ void SettingsDialog::on_bOk_clicked()
 
 void SettingsDialog::on_bHelp_clicked()
 {
-    QString helpUrl = Preferences::BASE_URL + QString::fromAscii("/help/client/megasync");
+    QString helpUrl = Preferences::BASE_URL + QString::fromLatin1("/help/client/megasync");
     QtConcurrent::run(QDesktopServices::openUrl, QUrl(helpUrl));
 }
 
@@ -979,7 +979,7 @@ void SettingsDialog::loadSettings()
             QString file = it.next();
             if (file.startsWith(fullPrefix))
             {
-                int extensionIndex = file.lastIndexOf(QString::fromAscii("."));
+                int extensionIndex = file.lastIndexOf(QString::fromLatin1("."));
                 if ((extensionIndex - fullPrefix.size()) <= 0)
                 {
                     continue;
@@ -1011,7 +1011,7 @@ void SettingsDialog::loadSettings()
 
         if (currentIndex == -1)
         {
-            currentIndex = languageCodes.indexOf(QString::fromAscii("en"));
+            currentIndex = languageCodes.indexOf(QString::fromLatin1("en"));
         }
 
         ui->cLanguage->addItems(languages);
@@ -1026,9 +1026,9 @@ void SettingsDialog::loadSettings()
             ui->bBandwidth->setText(tr("Transfers"));
         }
 
-        if (ui->lUploadAutoLimit->text().trimmed().at(0)!=QChar::fromAscii('('))
+        if (ui->lUploadAutoLimit->text().trimmed().at(0)!=QChar::fromLatin1('('))
         {
-            ui->lUploadAutoLimit->setText(QString::fromAscii("(%1)").arg(ui->lUploadAutoLimit->text().trimmed()));
+            ui->lUploadAutoLimit->setText(QString::fromLatin1("(%1)").arg(ui->lUploadAutoLimit->text().trimmed()));
         }
 
         // Disable Upgrade buttons for business accounts
@@ -1135,12 +1135,12 @@ void SettingsDialog::loadSettings()
         ui->rUploadAutoLimit->setChecked(preferences->uploadLimitKB()<0);
         ui->rUploadLimit->setChecked(preferences->uploadLimitKB()>0);
         ui->rUploadNoLimit->setChecked(preferences->uploadLimitKB()==0);
-        ui->eUploadLimit->setText((preferences->uploadLimitKB()<=0)? QString::fromAscii("0") : QString::number(preferences->uploadLimitKB()));
+        ui->eUploadLimit->setText((preferences->uploadLimitKB()<=0)? QString::fromLatin1("0") : QString::number(preferences->uploadLimitKB()));
         ui->eUploadLimit->setEnabled(ui->rUploadLimit->isChecked());
 
         ui->rDownloadLimit->setChecked(preferences->downloadLimitKB()>0);
         ui->rDownloadNoLimit->setChecked(preferences->downloadLimitKB()==0);
-        ui->eDownloadLimit->setText((preferences->downloadLimitKB()<=0)? QString::fromAscii("0") : QString::number(preferences->downloadLimitKB()));
+        ui->eDownloadLimit->setText((preferences->downloadLimitKB()<=0)? QString::fromLatin1("0") : QString::number(preferences->downloadLimitKB()));
         ui->eDownloadLimit->setEnabled(ui->rDownloadLimit->isChecked());
 
         ui->eMaxDownloadConnections->setValue(preferences->parallelDownloadConnections());
@@ -1429,7 +1429,7 @@ int SettingsDialog::saveSettings()
 
                 if (j == ui->tSyncs->rowCount())
                 {
-                    MegaApi::log(MegaApi::LOG_LEVEL_INFO, QString::fromAscii("Removing sync: %1").arg(preferences->getSyncName(i)).toUtf8().constData());
+                    MegaApi::log(MegaApi::LOG_LEVEL_INFO, QString::fromLatin1("Removing sync: %1").arg(preferences->getSyncName(i)).toUtf8().constData());
                     bool active = preferences->isFolderActive(i);
                     MegaNode *node = megaApi->getNodeByHandle(megaHandle);
                     if (active)
@@ -1497,7 +1497,7 @@ int SettingsDialog::saveSettings()
 
                 if (j == preferences->getNumSyncedFolders())
                 {
-                    MegaApi::log(MegaApi::LOG_LEVEL_INFO, QString::fromAscii("Adding sync: %1 - %2")
+                    MegaApi::log(MegaApi::LOG_LEVEL_INFO, QString::fromLatin1("Adding sync: %1 - %2")
                                  .arg(localFolderPath).arg(megaFolderPath).toUtf8().constData());
 
                     preferences->addSyncedFolder(localFolderPath,
@@ -1688,7 +1688,7 @@ int SettingsDialog::saveSettings()
                 string sProxyURL = proxySettings->getProxyURL();
                 QString proxyURL = QString::fromUtf8(sProxyURL.data());
 
-                QStringList parts = proxyURL.split(QString::fromAscii("://"));
+                QStringList parts = proxyURL.split(QString::fromLatin1("://"));
                 if (parts.size() == 2 && parts[0].startsWith(QString::fromUtf8("socks")))
                 {
                     proxy.setType(QNetworkProxy::Socks5Proxy);
@@ -1698,7 +1698,7 @@ int SettingsDialog::saveSettings()
                     proxy.setType(QNetworkProxy::HttpProxy);
                 }
 
-                QStringList arguments = parts[parts.size()-1].split(QString::fromAscii(":"));
+                QStringList arguments = parts[parts.size()-1].split(QString::fromLatin1(":"));
                 if (arguments.size() == 2)
                 {
                     proxy.setHostName(arguments[0]);
@@ -1747,7 +1747,7 @@ int SettingsDialog::saveSettings()
         preferences->setCrashed(true);
         excludedNamesChanged = false;
 
-        QMessageBox* info = new QMessageBox(QMessageBox::Warning, QString::fromAscii("MEGAsync"),
+        QMessageBox* info = new QMessageBox(QMessageBox::Warning, QString::fromLatin1("MEGAsync"),
                                             tr("The new excluded file names will be taken into account\n"
                                                "when the application starts again"));
         info->setStandardButtons(QMessageBox::Ok | QMessageBox::Yes);
@@ -1949,7 +1949,7 @@ void SettingsDialog::on_bUnlink_clicked()
 {
     QPointer<SettingsDialog> currentDialog = this;
     if (QMessageBox::question(NULL, tr("Logout"),
-            tr("Synchronization will stop working.") + QString::fromAscii(" ") + tr("Are you sure?"),
+            tr("Synchronization will stop working.") + QString::fromLatin1(" ") + tr("Are you sure?"),
             QMessageBox::Yes|QMessageBox::No) == QMessageBox::Yes)
     {
         if (currentDialog)
@@ -2016,7 +2016,7 @@ void SettingsDialog::on_tSyncs_doubleClicked(const QModelIndex &index)
         if (node)
         {
             const char *handle = node->getBase64Handle();
-            QString url = Preferences::BASE_URL + QString::fromAscii("/fm/") + QString::fromAscii(handle);
+            QString url = Preferences::BASE_URL + QString::fromLatin1("/fm/") + QString::fromLatin1(handle);
             QtConcurrent::run(QDesktopServices::openUrl, QUrl(url));
             delete [] handle;
             delete node;
@@ -2229,7 +2229,7 @@ void SettingsDialog::changeEvent(QEvent *event)
     if (event->type() == QEvent::LanguageChange)
     {
         ui->retranslateUi(this);
-        ui->bLocalCleaner->setText(ui->bLocalCleaner->text().arg(QString::fromAscii(MEGA_DEBRIS_FOLDER)));
+        ui->bLocalCleaner->setText(ui->bLocalCleaner->text().arg(QString::fromLatin1(MEGA_DEBRIS_FOLDER)));
         ui->lFileVersionsSize->setText(tr("File versions: %1").arg(Utilities::getSizeString(fileVersionsSize)));
 
 
@@ -2304,7 +2304,7 @@ void SettingsDialog::on_bClearCache_clicked()
     int numFolders = preferences->getNumSyncedFolders();
     for (int i = 0; i < numFolders; i++)
     {
-        QFileInfo fi(preferences->getLocalFolder(i) + QDir::separator() + QString::fromAscii(MEGA_DEBRIS_FOLDER));
+        QFileInfo fi(preferences->getLocalFolder(i) + QDir::separator() + QString::fromLatin1(MEGA_DEBRIS_FOLDER));
         if (fi.exists() && fi.isDir())
         {
             syncs += QString::fromUtf8("<br/><a href=\"local://#%1\">%2</a>")

--- a/src/MEGASync/gui/SetupWizard.cpp
+++ b/src/MEGASync/gui/SetupWizard.cpp
@@ -421,7 +421,7 @@ void SetupWizard::on_bNext_clicked()
             return;
         }
 
-        if (!email.contains(QChar::fromAscii('@')) || !email.contains(QChar::fromAscii('.')))
+        if (!email.contains(QChar::fromLatin1('@')) || !email.contains(QChar::fromLatin1('.')))
         {
             showErrorMessage(tr("Please, enter a valid e-mail address"));
             return;
@@ -462,7 +462,7 @@ void SetupWizard::on_bNext_clicked()
             return;
         }
 
-        if (!email.contains(QChar::fromAscii('@')) || !email.contains(QChar::fromAscii('.')))
+        if (!email.contains(QChar::fromLatin1('@')) || !email.contains(QChar::fromLatin1('.')))
         {
             showErrorMessage(tr("Please, enter a valid e-mail address"));
             return;
@@ -509,7 +509,7 @@ void SetupWizard::on_bNext_clicked()
             ui->eMegaFolder->setText(QString::fromUtf8("/MEGAsync"));
             ui->lAdvancedSetup->setText(tr("Selective sync:"));
             ui->lHeader->setText(tr("Setup selective sync"));
-            ui->bSyncType->setIcon(QIcon(QString::fromAscii("://images/step_4_selective_sync.png")));
+            ui->bSyncType->setIcon(QIcon(QString::fromLatin1("://images/step_4_selective_sync.png")));
             ui->bSyncType->setIconSize(QSize(94, 94));
             ui->lSyncType->setText(tr("Selective sync"));
             ui->lSyncTypeDesc->setText(tr("Specific folders in your Cloud Drive will be synchronized with a local folder."));
@@ -525,7 +525,7 @@ void SetupWizard::on_bNext_clicked()
             ui->eMegaFolder->setText(QString::fromUtf8("/"));
             ui->lAdvancedSetup->setText(tr("Select Local folder:"));
             ui->lHeader->setText(tr("Setup full sync"));
-            ui->bSyncType->setIcon(QIcon(QString::fromAscii("://images/step_4_full_sync.png")));
+            ui->bSyncType->setIcon(QIcon(QString::fromLatin1("://images/step_4_full_sync.png")));
             ui->bSyncType->setIconSize(QSize(94, 94));
             ui->lSyncType->setText(tr("Full Sync"));
             ui->lSyncTypeDesc->setText(tr("Your entire Cloud Drive will be synchronized with a local folder."));
@@ -541,12 +541,12 @@ void SetupWizard::on_bNext_clicked()
 
         if (!loggingStarted) //Logging started at main dialog
         {
-            ui->bCurrentStep->setIcon(QIcon(QString::fromAscii("://images/login_setup_step2.png")));
+            ui->bCurrentStep->setIcon(QIcon(QString::fromLatin1("://images/login_setup_step2.png")));
             ui->bCurrentStep->setIconSize(QSize(512, 44));
         }
         else
         {
-            ui->bCurrentStep->setIcon(QIcon(QString::fromAscii("://images/setup_step4.png")));
+            ui->bCurrentStep->setIcon(QIcon(QString::fromLatin1("://images/setup_step4.png")));
             ui->bCurrentStep->setIconSize(QSize(512, 44));
         }
 
@@ -1019,7 +1019,7 @@ void SetupWizard::page_login()
     ui->bNext->setDefault(true);
 
     ui->lHeader->setText(tr("Login to your MEGA account"));
-    ui->bCurrentStep->setIcon(QIcon(QString::fromAscii("://images/setup_step2.png")));
+    ui->bCurrentStep->setIcon(QIcon(QString::fromLatin1("://images/setup_step2.png")));
     ui->bCurrentStep->setIconSize(QSize(512, 44));
 
     ui->sPages->setCurrentWidget(ui->pLogin);
@@ -1070,14 +1070,14 @@ void SetupWizard::page_mode()
 
     if (!loggingStarted) //Logging started at main dialog
     {
-        ui->bCurrentStep->setIcon(QIcon(QString::fromAscii("://images/login_setup_step1.png")));
+        ui->bCurrentStep->setIcon(QIcon(QString::fromLatin1("://images/login_setup_step1.png")));
         ui->bCurrentStep->setIconSize(QSize(512, 44));
         ui->bBack->setVisible(false);
         ui->bBack->setEnabled(false);
     }
     else
     {
-        ui->bCurrentStep->setIcon(QIcon(QString::fromAscii("://images/setup_step3.png")));
+        ui->bCurrentStep->setIcon(QIcon(QString::fromLatin1("://images/setup_step3.png")));
         ui->bCurrentStep->setIconSize(QSize(512, 44));
         ui->bBack->setVisible(true);
         ui->bBack->setEnabled(true);
@@ -1107,12 +1107,12 @@ void SetupWizard::page_welcome()
 
     if (!loggingStarted) //Logging started at main dialog
     {
-        ui->bCurrentStep->setIcon(QIcon(QString::fromAscii("://images/login_setup_step3.png")));
+        ui->bCurrentStep->setIcon(QIcon(QString::fromLatin1("://images/login_setup_step3.png")));
         ui->bCurrentStep->setIconSize(QSize(512, 44));
     }
     else
     {
-        ui->bCurrentStep->setIcon(QIcon(QString::fromAscii("://images/setup_step5.png")));
+        ui->bCurrentStep->setIcon(QIcon(QString::fromLatin1("://images/setup_step5.png")));
         ui->bCurrentStep->setIconSize(QSize(512, 44));
     }
 
@@ -1149,7 +1149,7 @@ void SetupWizard::page_newaccount()
     ui->cAgreeWithTerms->setChecked(false);
 
     ui->lHeader->setText(tr("Create a new MEGA account"));
-    ui->bCurrentStep->setIcon(QIcon(QString::fromAscii("://images/setup_step1.png")));
+    ui->bCurrentStep->setIcon(QIcon(QString::fromLatin1("://images/setup_step1.png")));
     ui->bCurrentStep->setIconSize(QSize(512, 44));
 
     ui->sPages->setCurrentWidget(ui->pNewAccount);
@@ -1233,7 +1233,7 @@ void SetupWizard::on_lTermsLink_linkActivated(const QString &link)
 
 void SetupWizard::on_bLearMore_clicked()
 {
-    QString helpUrl = Preferences::BASE_URL + QString::fromAscii("/help/client/megasync/syncing/how-to-setup-sync-client-can-i-specify-which-folder-s-to-sync-576c80e2886688e6028b4591\\");
+    QString helpUrl = Preferences::BASE_URL + QString::fromLatin1("/help/client/megasync/syncing/how-to-setup-sync-client-can-i-specify-which-folder-s-to-sync-576c80e2886688e6028b4591\\");
     QtConcurrent::run(QDesktopServices::openUrl, QUrl(helpUrl));
 }
 

--- a/src/MEGASync/gui/StreamingFromMegaDialog.cpp
+++ b/src/MEGASync/gui/StreamingFromMegaDialog.cpp
@@ -261,7 +261,7 @@ void StreamingFromMegaDialog::onLinkInfoAvailable()
     if (selectedMegaNode)
     {
         QString name = QString::fromUtf8(selectedMegaNode->getName());
-        if (!name.compare(QString::fromAscii("NO_KEY")) || !name.compare(QString::fromAscii("CRYPTO_ERROR")))
+        if (!name.compare(QString::fromLatin1("NO_KEY")) || !name.compare(QString::fromLatin1("CRYPTO_ERROR")))
         {
             updateFileInfo(tr("Decryption error"), WARNING);
             delete selectedMegaNode;
@@ -294,8 +294,8 @@ void StreamingFromMegaDialog::openStreamWithApp(QString app)
 #else
     QString args;
     args = QString::fromUtf8("-a ");
-    args += QDir::toNativeSeparators(QString::fromUtf8("\"")+ app + QString::fromUtf8("\"")) + QString::fromAscii(" \"%1\"").arg(streamURL);
-    QProcess::startDetached(QString::fromAscii("open ") + args);
+    args += QDir::toNativeSeparators(QString::fromUtf8("\"")+ app + QString::fromUtf8("\"")) + QString::fromLatin1(" \"%1\"").arg(streamURL);
+    QProcess::startDetached(QString::fromLatin1("open ") + args);
 #endif
 }
 

--- a/src/MEGASync/gui/TransferManager.cpp
+++ b/src/MEGASync/gui/TransferManager.cpp
@@ -196,9 +196,9 @@ void TransferManager::createAddMenu()
     {
         addMenu = new QMenu(this);
 #ifdef __APPLE__
-        addMenu->setStyleSheet(QString::fromAscii("QMenu {background: #ffffff; padding-top: 8px; padding-bottom: 8px;}"));
+        addMenu->setStyleSheet(QString::fromLatin1("QMenu {background: #ffffff; padding-top: 8px; padding-bottom: 8px;}"));
 #else
-        addMenu->setStyleSheet(QString::fromAscii("QMenu { border: 1px solid #B8B8B8; border-radius: 5px; background: #ffffff; padding-top: 5px; padding-bottom: 5px;}"));
+        addMenu->setStyleSheet(QString::fromLatin1("QMenu { border: 1px solid #B8B8B8; border-radius: 5px; background: #ffffff; padding-top: 5px; padding-bottom: 5px;}"));
 #endif
     }
 
@@ -208,7 +208,7 @@ void TransferManager::createAddMenu()
         importLinksAction = NULL;
     }
 
-    importLinksAction = new MenuItemAction(tr("Import links"), QIcon(QString::fromAscii("://images/get_link_ico.png")), QIcon(QString::fromAscii("://images/get_link_ico_white.png")));
+    importLinksAction = new MenuItemAction(tr("Import links"), QIcon(QString::fromLatin1("://images/get_link_ico.png")), QIcon(QString::fromLatin1("://images/get_link_ico_white.png")));
     connect(importLinksAction, SIGNAL(triggered()), qApp, SLOT(importLinks()), Qt::QueuedConnection);
 
     if (uploadAction)
@@ -217,7 +217,7 @@ void TransferManager::createAddMenu()
         uploadAction = NULL;
     }
 
-    uploadAction = new MenuItemAction(tr("Upload"), QIcon(QString::fromAscii("://images/upload_to_mega_ico.png")), QIcon(QString::fromAscii("://images/upload_to_mega_ico_white.png")));
+    uploadAction = new MenuItemAction(tr("Upload"), QIcon(QString::fromLatin1("://images/upload_to_mega_ico.png")), QIcon(QString::fromLatin1("://images/upload_to_mega_ico_white.png")));
     connect(uploadAction, SIGNAL(triggered()), qApp, SLOT(uploadActionClicked()), Qt::QueuedConnection);
 
     if (downloadAction)
@@ -226,7 +226,7 @@ void TransferManager::createAddMenu()
         downloadAction = NULL;
     }
 
-    downloadAction = new MenuItemAction(tr("Download"), QIcon(QString::fromAscii("://images/download_from_mega_ico.png")), QIcon(QString::fromAscii("://images/download_from_mega_ico_white.png")));
+    downloadAction = new MenuItemAction(tr("Download"), QIcon(QString::fromLatin1("://images/download_from_mega_ico.png")), QIcon(QString::fromLatin1("://images/download_from_mega_ico_white.png")));
     connect(downloadAction, SIGNAL(triggered()), qApp, SLOT(downloadActionClicked()), Qt::QueuedConnection);
 
     if (settingsAction)
@@ -236,9 +236,9 @@ void TransferManager::createAddMenu()
     }
 
 #ifndef __APPLE__
-    settingsAction = new MenuItemAction(tr("Settings"), QIcon(QString::fromAscii("://images/settings_ico.png")), QIcon(QString::fromAscii("://images/settings_ico_white.png")));
+    settingsAction = new MenuItemAction(tr("Settings"), QIcon(QString::fromLatin1("://images/settings_ico.png")), QIcon(QString::fromLatin1("://images/settings_ico_white.png")));
 #else
-    settingsAction = new MenuItemAction(tr("Preferences"), QIcon(QString::fromAscii("://images/settings_ico.png")), QIcon(QString::fromAscii("://images/settings_ico_white.png")));
+    settingsAction = new MenuItemAction(tr("Preferences"), QIcon(QString::fromLatin1("://images/settings_ico.png")), QIcon(QString::fromLatin1("://images/settings_ico_white.png")));
 #endif
     connect(settingsAction, SIGNAL(triggered()), qApp, SLOT(openSettings()), Qt::QueuedConnection);
 

--- a/src/MEGASync/gui/TransferManagerItem.cpp
+++ b/src/MEGASync/gui/TransferManagerItem.cpp
@@ -197,7 +197,7 @@ void TransferManagerItem::updateTransfer()
             }
             else
             {
-                remainingTime = QString::fromAscii("");
+                remainingTime = QString::fromLatin1("");
             }
             ui->lRemainingTime->setText(remainingTime);
 

--- a/src/MEGASync/gui/TransfersStateInfoWidget.cpp
+++ b/src/MEGASync/gui/TransfersStateInfoWidget.cpp
@@ -22,20 +22,20 @@ void TransfersStateInfoWidget::setState(int newState)
     {
         case NO_DOWNLOADS:
             ui->lStatus->setText(tr("No Downloads"));
-            ui->lStatusIcon->setIcon(QIcon(QString::fromAscii("://images/no_downloads.png")));
+            ui->lStatusIcon->setIcon(QIcon(QString::fromLatin1("://images/no_downloads.png")));
             break;
         case NO_UPLOADS:
             ui->lStatus->setText(tr("No Uploads"));
-            ui->lStatusIcon->setIcon(QIcon(QString::fromAscii("://images/no_uploads.png")));
+            ui->lStatusIcon->setIcon(QIcon(QString::fromLatin1("://images/no_uploads.png")));
             break;
         case PAUSED:
             ui->lStatus->setText(tr("Paused Transfers"));
-            ui->lStatusIcon->setIcon(QIcon(QString::fromAscii("://images/paused_transfers.png")));
-            ui->wContainer->setStyleSheet((QString::fromAscii("background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,"
+            ui->lStatusIcon->setIcon(QIcon(QString::fromLatin1("://images/paused_transfers.png")));
+            ui->wContainer->setStyleSheet((QString::fromLatin1("background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,"
                                                               "stop: 0 rgba(252, 252, 252, 90%), stop: 1 rgba(247, 247, 247, 90%));")));
             break;
         default:
-            ui->lStatusIcon->setIcon(QIcon(QString::fromAscii("://images/completed_transfers.png")));
+            ui->lStatusIcon->setIcon(QIcon(QString::fromLatin1("://images/completed_transfers.png")));
             break;
     }
 }

--- a/src/MEGASync/gui/UpgradeOverStorage.cpp
+++ b/src/MEGASync/gui/UpgradeOverStorage.cpp
@@ -93,7 +93,7 @@ void UpgradeOverStorage::refreshUsedStorage()
         ui->pUsageStorage->style()->polish(ui->pUsageStorage);
 
         QString used = tr("%1 of %2").arg(QString::fromUtf8("<span style=\"color:#333333; font-size: 16px; text-decoration:none;\">%1</span>")
-                                     .arg(QString::number(percentage > 100 ? 100 : percentage).append(QString::fromAscii("%&nbsp;"))))
+                                     .arg(QString::number(percentage > 100 ? 100 : percentage).append(QString::fromLatin1("%&nbsp;"))))
                                      .arg(QString::fromUtf8("<span style=\"color:#333333; font-size: 16px; text-decoration:none;\">&nbsp;%1</span>")
                                      .arg(Utilities::getSizeString(totalStorage)));
         ui->lPercentageUsedStorage->setText(used);

--- a/src/MEGASync/gui/UpgradeWidget.cpp
+++ b/src/MEGASync/gui/UpgradeWidget.cpp
@@ -25,7 +25,7 @@ UpgradeWidget::UpgradeWidget(PlanInfo data, QString userAgent, QWidget *parent) 
     //that will be shown over the Plans to manage clicked() events
     overlay = new QPushButton(this);
     overlay->setObjectName(QString::fromUtf8("bOverlay"));
-    overlay->setStyleSheet(QString::fromAscii(
+    overlay->setStyleSheet(QString::fromLatin1(
                                "QPushButton#bOverlay:hover {border-image: url(://images/card_border.png);} "
                                "QPushButton#bOverlay {border-radius: 3px; border: 1px solid; border-color: rgba(0, 0, 0, 0.1); border: none;} "
                                ));

--- a/src/MEGASync/gui/UploadToMegaDialog.cpp
+++ b/src/MEGASync/gui/UploadToMegaDialog.cpp
@@ -70,7 +70,7 @@ void UploadToMegaDialog::onRequestFinish(MegaApi *, MegaRequest *request, MegaEr
     MegaNode *node = megaApi->getNodeByHandle(request->getNodeHandle());
     if (e->getErrorCode() != MegaError::API_OK || !node)
     {
-        MegaApi::log(MegaApi::LOG_LEVEL_ERROR, QString::fromAscii("Request error: %1")
+        MegaApi::log(MegaApi::LOG_LEVEL_ERROR, QString::fromLatin1("Request error: %1")
                      .arg(QCoreApplication::translate("MegaError", e->getErrorString())).toUtf8().constData());
         this->reject();
         delete node;

--- a/src/MEGASync/platform/linux/ExtServer.cpp
+++ b/src/MEGASync/platform/linux/ExtServer.cpp
@@ -16,7 +16,7 @@ ExtServer::ExtServer(MegaApplication *app): QObject(),
 
 
     // construct local socket path
-    sockPath = MegaApplication::applicationDataPath() + QDir::separator() + QString::fromAscii("mega.socket");
+    sockPath = MegaApplication::applicationDataPath() + QDir::separator() + QString::fromLatin1("mega.socket");
 
     //LOG_info << "Starting Ext server";
 
@@ -121,7 +121,7 @@ const char *ExtServer::GetAnswerToRequest(const char *buf)
             }
 
             bool ok;
-            QStringList parameters = QString::fromAscii(content).split(QChar::fromAscii(':'));
+            QStringList parameters = QString::fromLatin1(content).split(QChar::fromLatin1(':'));
 
             if (parameters.size() != 3)
             {

--- a/src/MEGASync/platform/linux/LinuxPlatform.cpp
+++ b/src/MEGASync/platform/linux/LinuxPlatform.cpp
@@ -7,8 +7,8 @@ using namespace mega;
 ExtServer *LinuxPlatform::ext_server = NULL;
 NotifyServer *LinuxPlatform::notify_server = NULL;
 
-static QString autostart_dir = QDir::homePath() + QString::fromAscii("/.config/autostart/");
-QString LinuxPlatform::desktop_file = autostart_dir + QString::fromAscii("megasync.desktop");
+static QString autostart_dir = QDir::homePath() + QString::fromLatin1("/.config/autostart/");
+QString LinuxPlatform::desktop_file = autostart_dir + QString::fromLatin1("megasync.desktop");
 QString LinuxPlatform::set_icon = QString::fromUtf8("gvfs-set-attribute -t string \"%1\" metadata::custom-icon file://%2");
 QString LinuxPlatform::remove_icon = QString::fromUtf8("gvfs-set-attribute -t unset \"%1\" metadata::custom-icon");
 QString LinuxPlatform::custom_icon = QString::fromUtf8("/usr/share/icons/hicolor/256x256/apps/mega.png");
@@ -58,7 +58,7 @@ bool LinuxPlatform::startOnStartup(bool value)
                     return false;
                 }
             }
-            QString app_desktop = QString::fromAscii("/usr/share/applications/megasync.desktop");
+            QString app_desktop = QString::fromLatin1("/usr/share/applications/megasync.desktop");
             if (QFile(app_desktop).exists())
             {
                 return QFile::copy(app_desktop, desktop_file);
@@ -89,7 +89,7 @@ bool LinuxPlatform::isStartOnStartupActive()
 void LinuxPlatform::showInFolder(QString pathIn)
 {
     QString filebrowser = getDefaultFileBrowserApp();
-    QProcess::startDetached(filebrowser + QString::fromAscii(" \"") + pathIn + QString::fromUtf8("\""));
+    QProcess::startDetached(filebrowser + QString::fromLatin1(" \"") + pathIn + QString::fromUtf8("\""));
 }
 
 void LinuxPlatform::startShellDispatcher(MegaApplication *receiver)
@@ -242,7 +242,7 @@ QString LinuxPlatform::getDefaultOpenAppByMimeType(QString mimeType)
     }
 
     QString line = contents.at(contents.size() - 1);
-    int index = line.indexOf(QChar::fromAscii('%'));
+    int index = line.indexOf(QChar::fromLatin1('%'));
     int size = -1;
     if (index != -1)
     {

--- a/src/MEGASync/platform/linux/NotifyServer.cpp
+++ b/src/MEGASync/platform/linux/NotifyServer.cpp
@@ -11,7 +11,7 @@ NotifyServer::NotifyServer(): QObject(),
     m_localServer(0)
 {
     // construct local socket path
-    sockPath = MegaApplication::applicationDataPath() + QDir::separator() + QString::fromAscii("notify.socket");
+    sockPath = MegaApplication::applicationDataPath() + QDir::separator() + QString::fromLatin1("notify.socket");
 
     //LOG_info << "Starting Notify server";
 

--- a/src/MEGASync/platform/macx/MacXExtServer.mm
+++ b/src/MEGASync/platform/macx/MacXExtServer.mm
@@ -60,7 +60,7 @@ void MacXExtServer::acceptConnection()
             }
 
             QString message = QString::fromUtf8("A:") + syncPath
-                    + QChar::fromAscii(':') + preferences->getSyncName(i);
+                    + QChar::fromLatin1(':') + preferences->getSyncName(i);
             client->writeData(message.toUtf8().constData(), message.length());
         }        
     }
@@ -134,7 +134,7 @@ bool MacXExtServer::GetAnswerToRequest(const char *buf, QByteArray *response)
             }
 
             bool ok;
-            QStringList parameters = QString::fromAscii(content).split(QChar::fromAscii(':'));
+            QStringList parameters = QString::fromLatin1(content).split(QChar::fromLatin1(':'));
             if (parameters.size() != 3)
             {
                 break;
@@ -370,7 +370,7 @@ void MacXExtServer::notifySyncAdd(QString path, QString syncName)
 {
     emit sendToAll((QString::fromUtf8("A:")
                    + path
-                   + QChar::fromAscii(':')
+                   + QChar::fromLatin1(':')
                    + syncName).toUtf8());
 }
 
@@ -378,7 +378,7 @@ void MacXExtServer::notifySyncDel(QString path, QString syncName)
 {
     emit sendToAll((QString::fromUtf8("D:")
                    + path
-                   + QChar::fromAscii(':')
+                   + QChar::fromLatin1(':')
                    + syncName).toUtf8());
 }
 
@@ -407,7 +407,7 @@ void MacXExtServer::notifyAllClients(int op)
             continue;
         }
 
-        QString message = command + syncPath + QChar::fromAscii(':') + preferences->getSyncName(i);
+        QString message = command + syncPath + QChar::fromLatin1(':') + preferences->getSyncName(i);
 
         emit sendToAll(message.toUtf8());
     }

--- a/src/MEGASync/platform/macx/MacXFunctions.mm
+++ b/src/MEGASync/platform/macx/MacXFunctions.mm
@@ -653,7 +653,7 @@ bool registerUpdateDaemon()
                << QString::fromUtf8("launchctl unload %1 && launchctl load %1").arg(path);
 
     QProcess p;
-    p.start(QString::fromAscii("bash"), scriptArgs);
+    p.start(QString::fromLatin1("bash"), scriptArgs);
     if (!p.waitForFinished(2000))
     {
         return false;

--- a/src/MEGASync/platform/macx/MacXPlatform.cpp
+++ b/src/MEGASync/platform/macx/MacXPlatform.cpp
@@ -43,7 +43,7 @@ void MacXPlatform::initialize(int argc, char *argv[])
         QDir appPath(app);
         appPath.cdUp();
         appPath.cdUp();
-        args.append(QString::fromAscii("-n"));
+        args.append(QString::fromLatin1("-n"));
         args.append(appPath.absolutePath());
         QProcess::startDetached(launchCommand, args);
         sleep(2);
@@ -101,7 +101,7 @@ bool MacXPlatform::isFinderExtensionEnabled()
                << kFinderSyncBundleId;
 
     QProcess p;
-    p.start(QString::fromAscii("pluginkit"), scriptArgs);
+    p.start(QString::fromLatin1("pluginkit"), scriptArgs);
     if (!p.waitForFinished(2000))
     {
         return false;
@@ -113,7 +113,7 @@ bool MacXPlatform::isFinderExtensionEnabled()
         return false;
     }
 
-    if (out.at(0) != QChar::fromAscii('?') && out.at(0) != QChar::fromAscii('+'))
+    if (out.at(0) != QChar::fromLatin1('?') && out.at(0) != QChar::fromLatin1('+'))
     {
         return false;
     }
@@ -143,7 +143,7 @@ void MacXPlatform::reloadFinderExtension()
                << QString::fromUtf8("tell application \"MEGAShellExtFinder\" to quit");
 
     QProcess p;
-    p.start(QString::fromAscii("osascript"), scriptArgs);
+    p.start(QString::fromLatin1("osascript"), scriptArgs);
     if (!p.waitForFinished(2000))
     {
         return;
@@ -175,7 +175,7 @@ void MacXPlatform::showInFolder(QString pathIn)
     scriptArgs.clear();
     scriptArgs << QString::fromUtf8("-e")
                << QString::fromUtf8("tell application \"Finder\" to activate");
-    QProcess::startDetached(QString::fromAscii("osascript"), scriptArgs);
+    QProcess::startDetached(QString::fromLatin1("osascript"), scriptArgs);
 }
 
 void MacXPlatform::startShellDispatcher(MegaApplication *receiver)

--- a/src/MEGASync/platform/win/WinShellDispatcherTask.cpp
+++ b/src/MEGASync/platform/win/WinShellDispatcherTask.cpp
@@ -356,7 +356,7 @@ VOID WinShellDispatcherTask::GetAnswerToRequest(LPPIPEINST pipe)
             }
 
             bool ok;
-            QStringList parameters = QString::fromWCharArray(content).split(QChar::fromAscii(':'));
+            QStringList parameters = QString::fromWCharArray(content).split(QChar::fromLatin1(':'));
             if (parameters.size() < 1)
             {
                 break;
@@ -404,7 +404,7 @@ VOID WinShellDispatcherTask::GetAnswerToRequest(LPPIPEINST pipe)
                 break;
             }
             QString filePath = QString::fromWCharArray(content);
-            if (filePath.startsWith(QString::fromAscii("\\\\?\\")))
+            if (filePath.startsWith(QString::fromLatin1("\\\\?\\")))
             {
                 filePath = filePath.mid(4);
             }
@@ -425,7 +425,7 @@ VOID WinShellDispatcherTask::GetAnswerToRequest(LPPIPEINST pipe)
             }
 
             QString filePath = QString::fromWCharArray(content);
-            if (filePath.startsWith(QString::fromAscii("\\\\?\\")))
+            if (filePath.startsWith(QString::fromLatin1("\\\\?\\")))
             {
                 filePath = filePath.mid(4);
             }
@@ -447,7 +447,7 @@ VOID WinShellDispatcherTask::GetAnswerToRequest(LPPIPEINST pipe)
             }
 
             bool overlayIcons = true;
-            QStringList parameters = QString::fromWCharArray(content).split(QChar::fromAscii('|'));
+            QStringList parameters = QString::fromWCharArray(content).split(QChar::fromLatin1('|'));
             if (parameters.size() > 1)
             {
                 bool ok;
@@ -465,7 +465,7 @@ VOID WinShellDispatcherTask::GetAnswerToRequest(LPPIPEINST pipe)
 
             int state;
             QString temp = parameters[0];
-            if (temp.startsWith(QString::fromAscii("\\\\?\\")))
+            if (temp.startsWith(QString::fromLatin1("\\\\?\\")))
             {
                 temp = temp.mid(4);
             }

--- a/src/MEGASync/platform/win/WindowsPlatform.cpp
+++ b/src/MEGASync/platform/win/WindowsPlatform.cpp
@@ -91,10 +91,10 @@ void WindowsPlatform::prepareForSync()
         for (int i = 1; i < data.size(); i++)
         {
             QString drive = data.at(i).trimmed();
-            if (drive.size() && drive.contains(QChar::fromAscii(':')))
+            if (drive.size() && drive.contains(QChar::fromLatin1(':')))
             {
                 int index = drive.indexOf(QString::fromUtf8(":"));
-                if (index >= 2 && drive[index - 2] == QChar::fromAscii(' '))
+                if (index >= 2 && drive[index - 2] == QChar::fromLatin1(' '))
                 {
                     drive = drive.mid(index - 1);
                     QStringList parts = drive.split(QString::fromUtf8(" "), QString::SkipEmptyParts);
@@ -649,7 +649,7 @@ bool WindowsPlatform::startOnStartup(bool value)
     }
 
     QString startupPath = QString::fromWCharArray(path);
-    startupPath += QString::fromAscii("\\MEGAsync.lnk");
+    startupPath += QString::fromLatin1("\\MEGAsync.lnk");
 
     if (value)
     {
@@ -690,7 +690,7 @@ bool WindowsPlatform::isStartOnStartupActive()
     }
 
     QString startupPath = QString::fromWCharArray(path);
-    startupPath += QString::fromAscii("\\MEGAsync.lnk");
+    startupPath += QString::fromLatin1("\\MEGAsync.lnk");
     if (QFileInfo(startupPath).isSymLink())
     {
         return true;
@@ -707,8 +707,8 @@ void WindowsPlatform::showInFolder(QString pathIn)
 
     QString param;
     param = QString::fromUtf8("/select,");
-    param += QString::fromAscii("\"\"") + QDir::toNativeSeparators(QDir(pathIn).canonicalPath()) + QString::fromAscii("\"\"");
-    QProcess::startDetached(QString::fromAscii("explorer ") + param);
+    param += QString::fromLatin1("\"\"") + QDir::toNativeSeparators(QDir(pathIn).canonicalPath()) + QString::fromLatin1("\"\"");
+    QProcess::startDetached(QString::fromLatin1("explorer ") + param);
 }
 
 void WindowsPlatform::startShellDispatcher(MegaApplication *receiver)
@@ -734,7 +734,7 @@ void WindowsPlatform::stopShellDispatcher()
 
 void WindowsPlatform::syncFolderAdded(QString syncPath, QString syncName, QString syncID)
 {
-    if (syncPath.startsWith(QString::fromAscii("\\\\?\\")))
+    if (syncPath.startsWith(QString::fromLatin1("\\\\?\\")))
     {
         syncPath = syncPath.mid(4);
     }
@@ -776,14 +776,14 @@ void WindowsPlatform::syncFolderAdded(QString syncPath, QString syncName, QStrin
     }
 
     QString linksPath = QString::fromWCharArray(path);
-    linksPath += QString::fromAscii("\\Links");
+    linksPath += QString::fromLatin1("\\Links");
     QFileInfo info(linksPath);
     if (!info.isDir())
     {
         return;
     }
 
-    QString linkPath = linksPath + QString::fromAscii("\\") + syncName + QString::fromAscii(".lnk");
+    QString linkPath = linksPath + QString::fromLatin1("\\") + syncName + QString::fromLatin1(".lnk");
     if (QFile(linkPath).exists())
     {
         return;
@@ -817,7 +817,7 @@ void WindowsPlatform::syncFolderRemoved(QString syncPath, QString syncName, QStr
 
     removeSyncFromLeftPane(syncPath, syncName, syncID);
 
-    if (syncPath.startsWith(QString::fromAscii("\\\\?\\")))
+    if (syncPath.startsWith(QString::fromLatin1("\\\\?\\")))
     {
         syncPath = syncPath.mid(4);
     }
@@ -835,14 +835,14 @@ void WindowsPlatform::syncFolderRemoved(QString syncPath, QString syncName, QStr
     }
 
     QString linksPath = QString::fromWCharArray(path);
-    linksPath += QString::fromAscii("\\Links");
+    linksPath += QString::fromLatin1("\\Links");
     QFileInfo info(linksPath);
     if (!info.isDir())
     {
         return;
     }
 
-    QString linkPath = linksPath + QString::fromAscii("\\") + syncName + QString::fromAscii(".lnk");
+    QString linkPath = linksPath + QString::fromLatin1("\\") + syncName + QString::fromLatin1(".lnk");
 
     QFile::remove(linkPath);
 


### PR DESCRIPTION
QString::fromAscii is deprecated in recent versions of Qt (Qt5), should be replaced by
QString::fromLatin1: see https://wiki.qt.io/Transition_from_Qt_4.x_to_Qt5