### PR TITLE
Fix typo: do -> due

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,4 +108,4 @@ Note: when compiling for Fedora/RHEL/CentOS and alike, `qmake` and `lrelease` mi
 
 Known Issues
 ------------
-For Solus, c-ares might not compile do to a CFLAG defined by gcc: -D_FORTIFY_SOURCE=2. This issue and its possible solution is described here https://github.com/c-ares/c-ares/issues/58 and http://ma.tc/ehuboqatec.md.
+For Solus, c-ares might not compile due to a CFLAG defined by gcc: -D_FORTIFY_SOURCE=2. This issue and its possible solution is described here https://github.com/c-ares/c-ares/issues/58 and http://ma.tc/ehuboqatec.md.


### PR DESCRIPTION
- Fix typo in README: _do_ **->** _due_