### PR TITLE
Fix build against qt5>=5.15

### DIFF
--- a/src/MEGASync/gui/MegaSpeedGraph.h
+++ b/src/MEGASync/gui/MegaSpeedGraph.h
@@ -2,6 +2,7 @@
 #define MEGASPEEDGRAPH_H
 
 #include <QWidget>
+#include <QPainterPath>
 #include "megaapi.h"
 
 namespace Ui {


### PR DESCRIPTION
Small adjustment required to build against `qt5:5.15`
Without compiler complains about `QtPainterPath has incomplete type and cannot be defined`
