### PR TITLE
Fix build with new glibc.

### DIFF
--- a/src/MEGASync/control/CrashHandler.cpp
+++ b/src/MEGASync/control/CrashHandler.cpp
@@ -209,7 +209,7 @@ string getDistroVersion()
         oss << "Error info:\n";
         if (info)
         {
-            oss << sys_siglist[sig] << " (" << sig << ") at address " << std::showbase << std::hex << info->si_addr << std::dec << "\n";
+            oss << strsignal(sig) << " (" << sig << ") at address " << std::showbase << std::hex << info->si_addr << std::dec << "\n";
         }
         else
         {


### PR DESCRIPTION
Description
-----------
Since sys_siglist deprecated and removed from glibc 2.32 need to use strsignal() instead.
