### PR TITLE
Add button to Retry All

### DIFF
--- a/src/MEGASync/gui/MegaTransferView.cpp
+++ b/src/MEGASync/gui/MegaTransferView.cpp
@@ -745,3 +745,13 @@ void MegaTransferView::clearAllTransferClicked()
         model->removeAllTransfers();
     }
 }
+
+
+void MegaTransferView::retryAllFailedTransferClicked()
+{
+    QTransfersModel *model = (QTransfersModel*)this->model();
+    if (model)
+    {
+        model->retryAllTransfers();
+    }
+}

--- a/src/MEGASync/gui/MegaTransferView.h
+++ b/src/MEGASync/gui/MegaTransferView.h
@@ -69,6 +69,7 @@ private slots:
     void clearTransferClicked();
     void clearAllTransferClicked();
 
+    void retryAllFailedTransferClicked();
 signals:
     void showContextMenu(QPoint pos);
 };

--- a/src/MEGASync/gui/QCustomTransfersModel.cpp
+++ b/src/MEGASync/gui/QCustomTransfersModel.cpp
@@ -334,42 +334,6 @@ void QCustomTransfersModel::updateActiveTransfer(MegaApi *api, MegaTransfer *new
     }
 }
 
-void QCustomTransfersModel::retryAllTransfers()
-{
-    retryAllCompletedTransfers(); 
-}
-
-
-void QCustomTransfersModel::retryAllCompletedTransfers()
-{
-    if (transfers.size())
-    {
-      // TODO: 
-      // Filter for failed transfers
-      // For each failed tx
-      //    retry the tx
-      //    possibly set whichever flags / state indicate its in progress
-      //    (i think the API does this for me though)
-      // 
-      // See following for how to retry.
-      // https://github.com/matthewstrasiotto/MEGAsync/blob/58d3ed7f4a10d08b0fa908639a65deac6a6bde1b/src/MEGASync/gui/MegaTransferDelegate.cpp#L292
-
-      for (QMap<int, TransferItemData*>::iterator it = transfers.begin(); it != transfers.end();)
-      {
-          int tag = it.key();
-
-          MegaTransfer *transfer = ((MegaApplication *)qApp)->getFinishedTransferByTag(tag);
-          if (transfer)
-          {
-              if (transfer->getLastError().getErrorCode())
-              {
-                  ((MegaApplication*)qApp)->getMegaApi()->retryTransfer(transfer);
-              }
-          }
-          
-      }
-    }
-}
 
 transfer_it QCustomTransfersModel::getInsertPosition(MegaTransfer *transfer)
 {

--- a/src/MEGASync/gui/QCustomTransfersModel.cpp
+++ b/src/MEGASync/gui/QCustomTransfersModel.cpp
@@ -353,6 +353,21 @@ void QCustomTransfersModel::retryAllCompletedTransfers()
       // 
       // See following for how to retry.
       // https://github.com/matthewstrasiotto/MEGAsync/blob/58d3ed7f4a10d08b0fa908639a65deac6a6bde1b/src/MEGASync/gui/MegaTransferDelegate.cpp#L292
+
+      for (QMap<int, TransferItemData*>::iterator it = transfers.begin(); it != transfers.end();)
+      {
+          int tag = it.key();
+
+          MegaTransfer *transfer = ((MegaApplication *)qApp)->getFinishedTransferByTag(tag);
+          if (transfer)
+          {
+              if (transfer->getLastError().getErrorCode())
+              {
+                  ((MegaApplication*)qApp)->getMegaApi()->retryTransfer(transfer);
+              }
+          }
+          
+      }
     }
 }
 

--- a/src/MEGASync/gui/QCustomTransfersModel.cpp
+++ b/src/MEGASync/gui/QCustomTransfersModel.cpp
@@ -334,6 +334,28 @@ void QCustomTransfersModel::updateActiveTransfer(MegaApi *api, MegaTransfer *new
     }
 }
 
+void QCustomTransfersModel::retryAllTransfers()
+{
+    retryAllCompletedTransfers(); 
+}
+
+
+void QCustomTransfersModel::retryAllCompletedTransfers()
+{
+    if (transfers.size())
+    {
+      // TODO: 
+      // Filter for failed transfers
+      // For each failed tx
+      //    retry the tx
+      //    possibly set whichever flags / state indicate its in progress
+      //    (i think the API does this for me though)
+      // 
+      // See following for how to retry.
+      // https://github.com/matthewstrasiotto/MEGAsync/blob/58d3ed7f4a10d08b0fa908639a65deac6a6bde1b/src/MEGASync/gui/MegaTransferDelegate.cpp#L292
+    }
+}
+
 transfer_it QCustomTransfersModel::getInsertPosition(MegaTransfer *transfer)
 {
     transfer_it it = transferOrder.begin();

--- a/src/MEGASync/gui/QCustomTransfersModel.h
+++ b/src/MEGASync/gui/QCustomTransfersModel.h
@@ -33,6 +33,7 @@ public:
 private slots:
     void refreshTransferItem(int tag);
     void removeAllCompletedTransfers();
+    void retryAllFailedTransfers(); 
 
 protected:
     void updateTransferInfo(mega::MegaTransfer *transfer);
@@ -42,6 +43,7 @@ public slots:
     void removeAllTransfers();
     void removeTransferByTag(int transferTag);
     void updateActiveTransfer(mega::MegaApi *api, mega::MegaTransfer *newtransfer);
+    void retryAllTransfers();
 
 private:
     unsigned char modelState;

--- a/src/MEGASync/gui/QCustomTransfersModel.h
+++ b/src/MEGASync/gui/QCustomTransfersModel.h
@@ -33,7 +33,6 @@ public:
 private slots:
     void refreshTransferItem(int tag);
     void removeAllCompletedTransfers();
-    void retryAllFailedTransfers(); 
 
 protected:
     void updateTransferInfo(mega::MegaTransfer *transfer);
@@ -43,7 +42,6 @@ public slots:
     void removeAllTransfers();
     void removeTransferByTag(int transferTag);
     void updateActiveTransfer(mega::MegaApi *api, mega::MegaTransfer *newtransfer);
-    void retryAllTransfers();
 
 private:
     unsigned char modelState;

--- a/src/MEGASync/gui/QFinishedTransfersModel.cpp
+++ b/src/MEGASync/gui/QFinishedTransfersModel.cpp
@@ -103,6 +103,43 @@ void QFinishedTransfersModel::removeAllTransfers()
     emit noTransfers();
 }
 
+void QFinishedTransfersModel::retryAllTransfers()
+{
+    retryAllCompletedTransfers(); 
+}
+
+
+void QFinishedTransfersModel::retryAllCompletedTransfers()
+{
+    if (transfers.size())
+    {
+      // TODO: 
+      // Filter for failed transfers
+      // For each failed tx
+      //    retry the tx
+      //    possibly set whichever flags / state indicate its in progress
+      //    (i think the API does this for me though)
+      // 
+      // See following for how to retry.
+      // https://github.com/matthewstrasiotto/MEGAsync/blob/58d3ed7f4a10d08b0fa908639a65deac6a6bde1b/src/MEGASync/gui/MegaTransferDelegate.cpp#L292
+
+      for (QMap<int, TransferItemData*>::iterator it = transfers.begin(); it != transfers.end();)
+      {
+          int tag = it.key();
+
+          MegaTransfer *transfer = ((MegaApplication *)qApp)->getFinishedTransferByTag(tag);
+          if (transfer)
+          {
+              if (transfer->getLastError().getErrorCode())
+              {
+                  ((MegaApplication*)qApp)->getMegaApi()->retryTransfer(transfer);
+              }
+          }
+          
+      }
+    }
+}
+
 MegaTransfer *QFinishedTransfersModel::getTransferByTag(int tag)
 {
     MegaTransfer *transfer = ((MegaApplication *)qApp)->getFinishedTransferByTag(tag);

--- a/src/MEGASync/gui/QFinishedTransfersModel.cpp
+++ b/src/MEGASync/gui/QFinishedTransfersModel.cpp
@@ -105,11 +105,11 @@ void QFinishedTransfersModel::removeAllTransfers()
 
 void QFinishedTransfersModel::retryAllTransfers()
 {
-    retryAllCompletedTransfers(); 
+    retryAllFailedTransfers(); 
 }
 
 
-void QFinishedTransfersModel::retryAllCompletedTransfers()
+void QFinishedTransfersModel::retryAllFailedTransfers()
 {
     if (transfers.size())
     {

--- a/src/MEGASync/gui/QFinishedTransfersModel.h
+++ b/src/MEGASync/gui/QFinishedTransfersModel.h
@@ -26,10 +26,12 @@ protected:
 
 private slots:
     void refreshTransferItem(int tag);
+    void retryAllFailedTransfers(); 
 
 public slots:
     void removeAllTransfers();
     void removeTransferByTag(int transferTag);
+    void retryAllTransfers();
 };
 
 #endif // QFINISHEDTRANSFERSMODEL_H

--- a/src/MEGASync/gui/QTransfersModel.cpp
+++ b/src/MEGASync/gui/QTransfersModel.cpp
@@ -72,3 +72,8 @@ QTransfersModel::~QTransfersModel()
 {
     qDeleteAll(transfers);
 }
+
+void QTransfersModel::retryAllTransfers()
+{
+  // Interface stub
+}

--- a/src/MEGASync/gui/QTransfersModel.h
+++ b/src/MEGASync/gui/QTransfersModel.h
@@ -43,7 +43,7 @@ public:
     virtual void removeTransferByTag(int transferTag) = 0;
     virtual void removeAllTransfers() = 0;
 
-    virtual void retryAllTransfers() = 0;
+    void retryAllTransfers();
 
     virtual mega::MegaTransfer *getTransferByTag(int tag) = 0;
 

--- a/src/MEGASync/gui/QTransfersModel.h
+++ b/src/MEGASync/gui/QTransfersModel.h
@@ -42,6 +42,9 @@ public:
 
     virtual void removeTransferByTag(int transferTag) = 0;
     virtual void removeAllTransfers() = 0;
+
+    virtual void retryAllTransfers() = 0;
+
     virtual mega::MegaTransfer *getTransferByTag(int tag) = 0;
 
     QCache<int, TransferItem> transferItems;

--- a/src/MEGASync/gui/TransferManager.cpp
+++ b/src/MEGASync/gui/TransferManager.cpp
@@ -469,21 +469,21 @@ void TransferManager::updateState()
     QWidget *w = ui->wTransfers->currentWidget();
     if (w == ui->wActiveTransfers)
     {
-        onTransfersActive(ui->wActiveTransfers->areTransfersActive());
+        onTransfersActive(ui->wActiveTransfers->areTransfersActive(), false);
     }
     else if (w == ui->wDownloads)
     {
-        onTransfersActive(ui->wDownloads->areTransfersActive());
+        onTransfersActive(ui->wDownloads->areTransfersActive(), false);
         ui->wDownloads->pausedTransfers(preferences->getDownloadsPaused());
     }
     else if (w == ui->wUploads)
     {
-        onTransfersActive(ui->wUploads->areTransfersActive());
+        onTransfersActive(ui->wUploads->areTransfersActive(), false);
         ui->wUploads->pausedTransfers(preferences->getUploadsPaused());
     }
     else if (w == ui->wCompleted)
     {
-        onTransfersActive(ui->wCompleted->areTransfersActive());
+        onTransfersActive(ui->wCompleted->areTransfersActive(), true);
     }
 }
 
@@ -556,9 +556,9 @@ void TransferManager::refreshFinishedTime()
     }
 }
 
-void TransferManager::onTransfersActive(bool exists)
+void TransferManager::onTransfersActive(bool clearExists, bool retryExists)
 {
-    ui->bClearAll->setEnabled(exists);
+    ui->bClearAll->setEnabled(clearExists);
 }
 
 void TransferManager::updateNumberOfCompletedTransfers(int num)

--- a/src/MEGASync/gui/TransferManager.cpp
+++ b/src/MEGASync/gui/TransferManager.cpp
@@ -633,3 +633,12 @@ void TransferManager::mouseReleaseEvent(QMouseEvent *event)
     dragPosition = QPoint(-1, -1);
 }
 
+
+void TransferManager::on_bRetryAll_clicked()
+{
+    QWidget *w = ui->wTransfers->currentWidget();
+    if(w == ui->wCompleted)
+    {
+        ui->wCompleted->retryTransfers();
+    }
+}

--- a/src/MEGASync/gui/TransferManager.h
+++ b/src/MEGASync/gui/TransferManager.h
@@ -76,6 +76,8 @@ private slots:
 
     void refreshFinishedTime();
 
+    void on_bRetryAll_clicked();
+
 protected:
     void changeEvent(QEvent *event);
     void mouseMoveEvent(QMouseEvent *event);

--- a/src/MEGASync/gui/TransferManager.h
+++ b/src/MEGASync/gui/TransferManager.h
@@ -59,7 +59,7 @@ private:
     QTimer *refreshTransferTime;
 
     void createAddMenu();
-    void onTransfersActive(bool exists);  
+    void onTransfersActive(bool clearExists, bool retryExists);
 
 public slots:
     void updateState();

--- a/src/MEGASync/gui/TransfersWidget.cpp
+++ b/src/MEGASync/gui/TransfersWidget.cpp
@@ -61,6 +61,11 @@ void TransfersWidget::clearTransfers()
     model->removeAllTransfers();
 }
 
+void TransfersWidget::retryTransfers()
+{
+    model->retryAllTransfers();
+}
+
 TransfersWidget::~TransfersWidget()
 {
     delete ui;

--- a/src/MEGASync/gui/TransfersWidget.h
+++ b/src/MEGASync/gui/TransfersWidget.h
@@ -25,6 +25,8 @@ public:
     void setupTransfers(mega::MegaTransferData *transferData, int type);
     void refreshTransferItems();
     void clearTransfers();
+
+    void retryTransfers();
     void pausedTransfers(bool paused);
     void disableGetLink(bool disable);
     QTransfersModel *getModel();

--- a/src/MEGASync/gui/linux/TransferManager.ui
+++ b/src/MEGASync/gui/linux/TransferManager.ui
@@ -77,7 +77,7 @@
   border: none;
 }
 
-#bClearAll:disabled, #bPause:disabled, #bAdd:disabled
+#bClearAll:disabled, #bPause:disabled, #bAdd:disabled, bRetryAll:disabled
 {
 	color: rgba(119, 119, 119, 30%);
 }
@@ -100,7 +100,7 @@
 
 }
 
-#bAdd:hover, #bPause::hover, #bClearAll::hover
+#bAdd:hover, #bPause::hover, #bClearAll::hover, bRetryAll:hover
 {
   border: 1px solid rgba(0, 0, 0, 20%);
   border-radius: 3px;
@@ -109,7 +109,7 @@
 
 }
 
-#bAdd:pressed, #bPause::pressed, #bClearAll::pressed
+#bAdd:pressed, #bPause::pressed, #bClearAll::pressed, bRetryAll:pressed
 {
   background-color: rgba(0, 0, 0, 10%);
   border: 1px solid rgba(0, 0, 0, 20%);
@@ -129,7 +129,7 @@
   font-style: normal;
   color: #ffffff;
 }
-#bClose::hover
+#bClose::hover, bRetryAll::hover
 {
   border: 1px solid rgba(0, 0, 0, 60%);
   border-radius: 3px;
@@ -137,7 +137,7 @@
                                       stop: 0 #999999, stop: 1 #aaaaaa);
 }
 
-#bClose::pressed
+#bClose::pressed, bRetryAll::pressed
 {
   border: 1px solid rgba(0, 0, 0, 60%);
   border-radius: 3px;

--- a/src/MEGASync/gui/linux/TransferManager.ui
+++ b/src/MEGASync/gui/linux/TransferManager.ui
@@ -292,7 +292,7 @@
                <string>Add...</string>
               </property>
               <property name="icon">
-               <iconset resource="../Resources_win.qrc">
+               <iconset resource="../Resources_linux.qrc">
                 <normaloff>:/images/ico_drop_add_sync.png</normaloff>:/images/ico_drop_add_sync.png</iconset>
               </property>
               <property name="iconSize">
@@ -798,6 +798,105 @@ border-top: 1px solid rgba(0, 0, 0, 10%);
         <property name="icon">
          <iconset resource="../Resources_linux.qrc">
           <normaloff>:/images/clear_ico.png</normaloff>:/images/clear_ico.png</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>24</width>
+          <height>24</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="bRetryAll">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="palette">
+         <palette>
+          <active>
+           <colorrole role="Button">
+            <brush brushstyle="SolidPattern">
+             <color alpha="255">
+              <red>255</red>
+              <green>255</green>
+              <blue>255</blue>
+             </color>
+            </brush>
+           </colorrole>
+           <colorrole role="ButtonText">
+            <brush brushstyle="SolidPattern">
+             <color alpha="255">
+              <red>46</red>
+              <green>52</green>
+              <blue>54</blue>
+             </color>
+            </brush>
+           </colorrole>
+          </active>
+          <inactive>
+           <colorrole role="Button">
+            <brush brushstyle="SolidPattern">
+             <color alpha="255">
+              <red>202</red>
+              <green>202</green>
+              <blue>202</blue>
+             </color>
+            </brush>
+           </colorrole>
+           <colorrole role="ButtonText">
+            <brush brushstyle="SolidPattern">
+             <color alpha="255">
+              <red>231</red>
+              <green>231</green>
+              <blue>231</blue>
+             </color>
+            </brush>
+           </colorrole>
+          </inactive>
+          <disabled>
+           <colorrole role="Button">
+            <brush brushstyle="SolidPattern">
+             <color alpha="255">
+              <red>202</red>
+              <green>202</green>
+              <blue>202</blue>
+             </color>
+            </brush>
+           </colorrole>
+           <colorrole role="ButtonText">
+            <brush brushstyle="SolidPattern">
+             <color alpha="127">
+              <red>255</red>
+              <green>255</green>
+              <blue>255</blue>
+             </color>
+            </brush>
+           </colorrole>
+          </disabled>
+         </palette>
+        </property>
+        <property name="cursor">
+         <cursorShape>PointingHandCursor</cursorShape>
+        </property>
+        <property name="text">
+         <string>Retry All</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../Resources_linux.qrc">
+          <normaloff>:/images/ico_item_retry@3x.png</normaloff>:/images/ico_item_retry@3x.png</iconset>
         </property>
         <property name="iconSize">
          <size>

--- a/src/MEGASync/gui/linux/TransfersWidget.ui
+++ b/src/MEGASync/gui/linux/TransfersWidget.ui
@@ -97,7 +97,7 @@
       <string notr="true"/>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="TransfersStateInfoWidget" name="pNoTransfers">
       <property name="sizePolicy">

--- a/src/MEGASync/gui/macx/TransferManager.ui
+++ b/src/MEGASync/gui/macx/TransferManager.ui
@@ -66,7 +66,7 @@
   border: none;
 }
 
-#bClearAll:disabled, #bPause:disabled, #bAdd:disabled
+#bClearAll:disabled, #bPause:disabled, #bAdd:disabled, bRetryAll:disabled
 {
 	color: rgba(119, 119, 119, 30%);
 }
@@ -89,7 +89,7 @@
 
 }
 
-#bAdd:hover, #bPause::hover, #bClearAll::hover
+#bAdd:hover, #bPause::hover, #bClearAll::hover, bRetryAll:hover
 {
   border: 1px solid rgba(0, 0, 0, 20%);
   border-radius: 3px;
@@ -98,7 +98,7 @@
 
 }
 
-#bAdd:pressed, #bPause::pressed, #bClearAll::pressed
+#bAdd:pressed, #bPause::pressed, #bClearAll::pressed, bRetryAll:pressed
 {
   background-color: rgba(0, 0, 0, 10%);
   border: 1px solid rgba(0, 0, 0, 20%);
@@ -118,7 +118,7 @@
   font-style: normal;
   color: #ffffff;
 }
-#bClose::hover
+#bClose::hover, bRetryAll::hover
 {
   border: 1px solid rgba(0, 0, 0, 60%);
   border-radius: 3px;
@@ -126,7 +126,7 @@
                                       stop: 0 #999999, stop: 1 #aaaaaa);
 }
 
-#bClose::pressed
+#bClose::pressed, bRetryAll::pressed
 {
   border: 1px solid rgba(0, 0, 0, 60%);
   border-radius: 3px;

--- a/src/MEGASync/gui/macx/TransferManager.ui
+++ b/src/MEGASync/gui/macx/TransferManager.ui
@@ -786,7 +786,42 @@ border-top: 1px solid rgba(0, 0, 0, 10%);
          <string>Clear all</string>
         </property>
         <property name="icon">
-         <iconset resource="../Resources_macx.qrc">
+         <iconset resource="../Resources_linux.qrc">
+          <normaloff>:/images/clear_ico.png</normaloff>:/images/clear_ico.png</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>24</width>
+          <height>24</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="bRetryAll">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="cursor">
+         <cursorShape>ArrowCursor</cursorShape>
+        </property>
+        <property name="text">
+         <string>Clear all</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../Resources_linux.qrc">
           <normaloff>:/images/clear_ico.png</normaloff>:/images/clear_ico.png</iconset>
         </property>
         <property name="iconSize">

--- a/src/MEGASync/gui/win/TransferManager.ui
+++ b/src/MEGASync/gui/win/TransferManager.ui
@@ -795,7 +795,42 @@ border-top: 1px solid rgba(0, 0, 0, 10%);
          <string>Clear all</string>
         </property>
         <property name="icon">
-         <iconset resource="../Resources_win.qrc">
+         <iconset resource="../Resources_linux.qrc">
+          <normaloff>:/images/clear_ico.png</normaloff>:/images/clear_ico.png</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>24</width>
+          <height>24</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="bRetryAll">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="cursor">
+         <cursorShape>PointingHandCursor</cursorShape>
+        </property>
+        <property name="text">
+         <string>Clear all</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../Resources_linux.qrc">
           <normaloff>:/images/clear_ico.png</normaloff>:/images/clear_ico.png</iconset>
         </property>
         <property name="iconSize">

--- a/src/MEGASync/gui/win/TransferManager.ui
+++ b/src/MEGASync/gui/win/TransferManager.ui
@@ -76,7 +76,7 @@
   border: none;
 }
 
-#bClearAll:disabled, #bPause:disabled, #bAdd:disabled
+#bClearAll:disabled, #bPause:disabled, #bAdd:disabled, bRetryAll:disabled
 {
 	color: rgba(119, 119, 119, 30%);
 }
@@ -99,7 +99,7 @@
 
 }
 
-#bAdd:hover, #bPause::hover, #bClearAll::hover
+#bAdd:hover, #bPause::hover, #bClearAll::hover, bRetryAll:hover
 {
   border: 1px solid rgba(0, 0, 0, 20%);
   border-radius: 3px;
@@ -108,7 +108,7 @@
 
 }
 
-#bAdd:pressed, #bPause::pressed, #bClearAll::pressed
+#bAdd:pressed, #bPause::pressed, #bClearAll::pressed, bRetryAll:pressed
 {
   background-color: rgba(0, 0, 0, 10%);
   border: 1px solid rgba(0, 0, 0, 20%);
@@ -128,7 +128,7 @@
   font-style: normal;
   color: #ffffff;
 }
-#bClose::hover
+#bClose::hover, bRetryAll::hover
 {
   border: 1px solid rgba(0, 0, 0, 60%);
   border-radius: 3px;
@@ -136,7 +136,7 @@
                                       stop: 0 #999999, stop: 1 #aaaaaa);
 }
 
-#bClose::pressed
+#bClose::pressed, bRetryAll::pressed
 {
   border: 1px solid rgba(0, 0, 0, 60%);
   border-radius: 3px;


### PR DESCRIPTION
Description
-----------

See #498 

> When transfers fail, they tend to fail in masses. 
> 
> Something like running out of diskspace will basically trash your whole queue, & if you had a large queue ( you likely did if you ran out of space), there's no easy way to save this state, restore it, nor understand what did or didn't succeed
> 
> ## Present Workflow for restoring failures
> 
> Presently, the only workflow available for restoring is to scroll through the info dialogue widget & manually click the retry action that appears next to each element that's failed. 
> 
> While doing this, the user must contend with the following:
> 
> - The Tranfer list is continually refreshing & re-sorting as items are actioned, 
>   -  :x: It's very easy to lose one's place & get lost in what you did or didn't click
> - The scrolling speed is almost an entire viewport of elements per scroll
>   -  :x: To scroll, while also retrying items the user must scroll, then click through each item on the viewport
> - The actual target size for the action button is deceptively small
>   - :x: To ensure that I was actually getting through items I had to click each one multiple times

## Suggested workflow

A "Retry All" Button would be super helpful

## Problems with my implementation

I'm not really sure how to get the styling right on the button - I've got my build running for actual downloads atm so I won't be able to actually investigate. 

Also, I haven't actually tested this WRT any actual failed transfers, as I'd already sorted out my diskspace by the time I got to test it, but once everything is finished I'll be able to.

Redmine ticket(s)
-----------------

?

Risk area(s)
------------

?