### PR TITLE
feat: add AppData manifest

### DIFF
--- a/src/MEGASync/platform/linux/data/nz.mega.MEGAsync.metainfo.xml
+++ b/src/MEGASync/platform/linux/data/nz.mega.MEGAsync.metainfo.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2020 Artem Polishchuk <ego.cordatus@gmail.com> -->
+<component type="desktop-application">
+  <id>nz.mega.MEGAsync</id>
+  <metadata_license>CC0-1.0</metadata_license>
+
+  <!-- MEGAsync is under a proprietary license, except the SDK which is BSD -->
+  <project_license>LicenseRef-proprietary</project_license>
+
+  <name>MEGAsync</name>
+  <provides>
+    <binary>megasync</binary>
+  </provides>
+
+  <content_rating type="oars-1.0">
+  </content_rating>
+
+  <summary>
+    Easy automated syncing between your computers and your MEGA Cloud Drive.
+  </summary>
+
+  <description>
+    <p>Easy automated syncing between your computers and your MEGA cloud drive.</p>
+  </description>
+
+  <releases>
+    <release date="@DATE@" version="@VERSION@"></release>
+    <release date="2020-07-27" version="v4.3.3.0_Linux"></release>
+  </releases>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://eu.static.mega.co.nz/3//images/mega/bottom-page/sp_sync_1_v3@2x.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://eu.static.mega.co.nz/3//images/mega/bottom-page/sp_sync_2_v2@2x.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://eu.static.mega.co.nz/3//images/mega/bottom-page/sp_sync_3_v2@2x.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://eu.static.mega.co.nz/3//images/mega/bottom-page/sp_sync_4@2x.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://eu.static.mega.co.nz/3//images/mega/bottom-page/sp_sync_5@2x.png</image>
+    </screenshot>
+  </screenshots>
+
+  <keywords>
+    <keyword>cloud</keyword>
+    <keyword>filesharing</keyword>
+    <keyword>sync</keyword>
+  </keywords>
+
+  <url type="bugtracker">https://github.com/meganz/MEGAsync/issues</url>
+  <url type="help">https://mega.nz/help/client/megasync/</url>
+  <url type="homepage">https://mega.nz/sync</url>
+</component>


### PR DESCRIPTION
Description
-----------
Every software center that exists allows the user to look at
screenshots and a long description of the application before it is
installed. For most users it allows them to answer the question “Do I
want to install this application?”. Traditionally in Linux
distributions, we have none of this data for the vast majority of our
desktop user-installable applications.

More info:
https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html

Risk area(s)
------------
None.

---
Related: https://github.com/flathub/flathub/pull/1933