### PR TITLE
Add support for Wayland

### DIFF
--- a/src/MEGASync/gui/InfoDialog.cpp
+++ b/src/MEGASync/gui/InfoDialog.cpp
@@ -110,7 +110,7 @@ InfoDialog::InfoDialog(MegaApplication *app, QWidget *parent, InfoDialog* olddia
         // To avoid issues with text input we implement a popup ourselves
         // instead of using Qt::Popup by listening to the WindowDeactivate
         // event.
-        Qt::WindowFlags flags = Qt::FramelessWindowHint;
+        Qt::WindowFlags flags = Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint;
 
         if (Platform::isTilingWindowManager())
         {

--- a/src/MEGASync/platform/linux/LinuxPlatform.cpp
+++ b/src/MEGASync/platform/linux/LinuxPlatform.cpp
@@ -309,13 +309,20 @@ QString LinuxPlatform::getWindowManagerName()
 
     if (!cached)
     {
+	    xcb_connection_t* conn = QX11Info::connection();
+	    if (conn == nullptr) {
+	    	cached = true;
+	    	window_manager_name = "";
+	    	goto NO_X11;
+	    }
         window_manager_name =
-          getProperty(QX11Info::connection(),
+          getProperty(conn,
                       QX11Info::appRootWindow(),
                       "_NET_WM_NAME");
 
         cached = true;
     }
+    NO_X11:
 
     return QString::fromStdString(window_manager_name);
 }

--- a/src/MEGASync/platform/linux/LinuxPlatform.cpp
+++ b/src/MEGASync/platform/linux/LinuxPlatform.cpp
@@ -104,7 +104,8 @@ bool LinuxPlatform::isStartOnStartupActive()
 bool LinuxPlatform::isTilingWindowManager()
 {
     static const QSet<QString> tiling_wms = {
-        QString::fromUtf8("i3")
+        QString::fromUtf8("i3"),
+        QString::fromUtf8("sway")
     };
 
     return getValue("MEGASYNC_ASSUME_TILING_WM", false)
@@ -309,16 +310,20 @@ QString LinuxPlatform::getWindowManagerName()
 
     if (!cached)
     {
-	    xcb_connection_t* conn = QX11Info::connection();
-	    if (conn == nullptr) {
-	    	cached = true;
-	    	window_manager_name = "";
-	    	goto NO_X11;
-	    }
-        window_manager_name =
-          getProperty(conn,
-                      QX11Info::appRootWindow(),
-                      "_NET_WM_NAME");
+    	if (qgetenv("XDG_SESSION_TYPE") == "wayland") {
+    		window_manager_name = qgetenv("XDG_CURRENT_DESKTOP");
+    	} else {
+		    xcb_connection_t* conn = QX11Info::connection();
+		    if (conn != nullptr) {
+			    window_manager_name =
+					    getProperty(conn,
+					                QX11Info::appRootWindow(),
+					                "_NET_WM_NAME");
+		    } else {
+			    window_manager_name = "";
+		    }
+    	}
+
 
         cached = true;
     }

--- a/src/MEGASync/platform/linux/LinuxPlatform.cpp
+++ b/src/MEGASync/platform/linux/LinuxPlatform.cpp
@@ -311,7 +311,7 @@ QString LinuxPlatform::getWindowManagerName()
     if (!cached)
     {
     	if (qgetenv("XDG_SESSION_TYPE") == "wayland") {
-    		window_manager_name = qgetenv("XDG_CURRENT_DESKTOP");
+    		window_manager_name = qgetenv("XDG_CURRENT_DESKTOP").toStdString();
     	} else {
 		    xcb_connection_t* conn = QX11Info::connection();
 		    if (conn != nullptr) {


### PR DESCRIPTION
Description
-----------
Qt supports wayland, however due to the implementation, megasync segfaults on trying to obtain the wm name. this PR uses the XDG_SESSION_TYPE environment variable to detect wayland, and if so, uses XDG_CURRENT_DESKTOP to get the WM name.
