### PR TITLE
Double icon resolution

### DIFF
--- a/src/MEGASync/MegaApplication.cpp
+++ b/src/MEGASync/MegaApplication.cpp
@@ -6459,11 +6459,11 @@ void MegaApplication::createInfoDialogMenus()
 
     if (updateAvailable)
     {
-        updateAction = new MenuItemAction(tr("Install update"), QIcon(QString::fromUtf8("://images/ico_about_MEGA.png")), true);
+        updateAction = new MenuItemAction(tr("Install update"), QIcon(QString::fromUtf8("://images/ico_about_MEGA@2x.png")), true);
     }
     else
     {
-        updateAction = new MenuItemAction(tr("About MEGAsync"), QIcon(QString::fromUtf8("://images/ico_about_MEGA.png")), true);
+        updateAction = new MenuItemAction(tr("About MEGAsync"), QIcon(QString::fromUtf8("://images/ico_about_MEGA@2x.png")), true);
     }
     connect(updateAction, SIGNAL(triggered()), this, SLOT(onInstallUpdateClicked()), Qt::QueuedConnection);
 


### PR DESCRIPTION
**Description**
Simply doubles icon resolution.

![image](https://user-images.githubusercontent.com/51381523/151533939-fe753461-7ad5-451a-8ef9-c0ff49b4fb4e.png)
The icon is currently quite pixelated, I think this can be fixed by doubling the resolution, but I'm not sure of the effects on other desktop environments.
