### PR TITLE
Add Xmonad to tiling_wms list

### DIFF
--- a/src/MEGASync/platform/linux/LinuxPlatform.cpp
+++ b/src/MEGASync/platform/linux/LinuxPlatform.cpp
@@ -104,7 +104,8 @@ bool LinuxPlatform::isStartOnStartupActive()
 bool LinuxPlatform::isTilingWindowManager()
 {
     static const QSet<QString> tiling_wms = {
-        QString::fromUtf8("i3")
+        QString::fromUtf8("i3"),
+        QString::fromUtf8("xmonad")
     };
 
     return getValue("MEGASYNC_ASSUME_TILING_WM", false)


### PR DESCRIPTION
Description
-----------

Added an additional **Xmonad** tiling window manager so that MEGAsync can detect
it and adjust for such an environment. The goals are the same as in -- to fix
the display of the MEGAsync dialog, because in tiling environments it is tiled,
stretched and placed in a wrong place than it has to be.

SDK Submodule build
-------------------
#You can change submodule branch here. Default develop.
SDK_SUBMODULE_TEST=develop


Risk area(s)
------------


Tested in
---------
Win | Linux | macOS

