### PR TITLE
Replace apt-key with shared keyring

### DIFF
--- a/build/MEGAsync/MEGAsync/debian.postinst
+++ b/build/MEGAsync/MEGAsync/debian.postinst
@@ -92,11 +92,12 @@ fi
 
 if [ -d /etc/apt/sources.list.d ]; then
 cat >/etc/apt/sources.list.d/megasync.list <<EOF
-deb https://mega.nz/linux/repo/$str/ ./
+deb [signed-by=/usr/share/keyrings/meganz.gpg] https://mega.nz/linux/repo/$str/ ./
 EOF
 fi
 
-apt-key add - >/dev/null 2>&1 <<KEY
+apt-key del support@mega.co.nz
+cat <<KEY | gpg --dearmor > /usr/share/keyrings/meganz.gpg
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQINBGHe0SkBEADd5u7XBExxSg6stILhfNTNfhtTQ3ZSTLW0JZrni1inMS+P8aEM


### PR DESCRIPTION
Description
-----------
apt-key is deprecated. This PR fixes #683 using the solution suggested there. Please refer to #683 for a detailed explanation of the how and why.

My code is a bit sloppy, so please read it carefully. But I thought this was better than only opening an issue.

SDK Submodule build
-------------------
#You can change submodule branch here. Default develop.
SDK_SUBMODULE_TEST=develop


Risk area(s)
------------
* Should the key be stored as `meganz.gpg` or is a different name preferred?
* Is the `debian.postinst` the appropriate place to remove the old key?
  It's essentially a migration step from older versions.

Tested in
---------
Debian testing