### PR TITLE
Add OS detection 

### DIFF
--- a/contrib/build_qt/qt/env.source
+++ b/contrib/build_qt/qt/env.source
@@ -19,7 +19,16 @@ else
   BIN_DIR="${BIN_DIR:-$ENV_ROOT/bin}"
 
   export LDFLAGS="-L${TARGET_DIR}/lib"
-  # FIXME: detect OS somehow
+
+if [[ $(uname) == "Darwin" ]];then
+  export OS="$(sw_vers -productName) $(sw_vers -productVersion) $(sw_vers -buildVersion)"
+  export OS_ARCHITECTURE=$(uname -m)
+  export OS_NAME=$(uname)
+else
+  export OS=$(cat /etc/issue)
+  export OS_ARCHITECTURE=$(uname -m)
+  export OS_NAME=$(uname -o)
+fi
   export DYLD_LIBRARY_PATH="${TARGET_DIR}/lib"
   export PKG_CONFIG_PATH="$TARGET_DIR/lib/pkgconfig"
   #export CFLAGS="-I${TARGET_DIR}/include $LDFLAGS -static-libgcc -Wl,-Bstatic -lc"


### PR DESCRIPTION
Description
-----------
Add  OS detection in shell script for Linux and Mac

SDK Submodule build
-------------------
#You can change submodule branch here. Default develop.
SDK_SUBMODULE_TEST=develop


Risk area(s)
------------


Tested in
---------
Linux | macOS

