### PR TITLE
Cleanup obsolete files: remove references to removed files

### DIFF
--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -193,7 +193,6 @@ set (FORMS
     ${MEGAsyncDir}/gui/${UiDir}/MegaProgressCustomDialog.ui
     ${MEGAsyncDir}/gui/${UiDir}/PlanWidget.ui
     ${MEGAsyncDir}/gui/${UiDir}/UpgradeDialog.ui
-    ${MEGAsyncDir}/gui/${UiDir}/AddExclusionDialog.ui
     ${MEGAsyncDir}/gui/${UiDir}/StatusInfo.ui
     ${MEGAsyncDir}/gui/${UiDir}/PSAwidget.ui
     ${MEGAsyncDir}/gui/${UiDir}/UpgradeOverStorage.ui
@@ -328,7 +327,6 @@ set (MOC_INPUT
     ${MEGAsyncDir}/gui/QAlertsModel.h
     ${MEGAsyncDir}/gui/QFilterAlertsModel.h
     ${MEGAsyncDir}/gui/AccountDetailsDialog.h
-    ${MEGAsyncDir}/gui/AddExclusionDialog.h
     ${MEGAsyncDir}/gui/AvatarWidget.h
     ${MEGAsyncDir}/gui/MenuItemAction.h
     ${MEGAsyncDir}/gui/MegaUserAlertExt.h
@@ -623,7 +621,6 @@ set (SRCS
     ${MEGAsyncDir}/gui/AvatarWidget.cpp
     ${MEGAsyncDir}/gui/MenuItemAction.cpp
     ${MEGAsyncDir}/gui/MegaUserAlertExt.cpp
-    ${MEGAsyncDir}/gui/AddExclusionDialog.cpp
     ${MEGAsyncDir}/gui/StatusInfo.cpp
     ${MEGAsyncDir}/gui/ChangePassword.cpp
     ${MEGAsyncDir}/gui/PasswordLineEdit.cpp

--- a/src/MEGASync/gui/gui.pri
+++ b/src/MEGASync/gui/gui.pri
@@ -38,7 +38,6 @@ SOURCES += $$PWD/SettingsDialog.cpp \
     $$PWD/QMegaMessageBox.cpp \
     $$PWD/AvatarWidget.cpp \
     $$PWD/MenuItemAction.cpp \
-    $$PWD/AddExclusionDialog.cpp \
     $$PWD/StatusInfo.cpp \
     $$PWD/ChangePassword.cpp \
     $$PWD/PSAwidget.cpp \
@@ -136,7 +135,6 @@ HEADERS  += $$PWD/SettingsDialog.h \
     $$PWD/QMegaMessageBox.h \
     $$PWD/AvatarWidget.h \
     $$PWD/MenuItemAction.h \
-    $$PWD/AddExclusionDialog.h \
     $$PWD/StatusInfo.h \
     $$PWD/PSAwidget.h \
     $$PWD/ElidedLabel.h \
@@ -226,7 +224,6 @@ win32 {
                 $$PWD/win/MegaProgressCustomDialog.ui \
                 $$PWD/win/PlanWidget.ui \
                 $$PWD/win/UpgradeDialog.ui \
-                $$PWD/win/AddExclusionDialog.ui \
                 $$PWD/win/StatusInfo.ui \
                 $$PWD/win/PSAwidget.ui \
                 $$PWD/win/RemoteItemUi.ui \
@@ -274,7 +271,6 @@ macx {
                 $$PWD/macx/MegaProgressCustomDialog.ui \
                 $$PWD/macx/PlanWidget.ui \
                 $$PWD/macx/UpgradeDialog.ui \
-                $$PWD/macx/AddExclusionDialog.ui \
                 $$PWD/macx/StatusInfo.ui \
                 $$PWD/macx/PSAwidget.ui \
                 $$PWD/macx/RemoteItemUi.ui\
@@ -345,7 +341,6 @@ unix:!macx {
                 $$PWD/linux/MegaProgressCustomDialog.ui \
                 $$PWD/linux/PlanWidget.ui \
                 $$PWD/linux/UpgradeDialog.ui \
-                $$PWD/linux/AddExclusionDialog.ui \
                 $$PWD/linux/StatusInfo.ui \
                 $$PWD/linux/PSAwidget.ui \
                 $$PWD/linux/UpgradeOverStorage.ui \


### PR DESCRIPTION
28779e6e7ffd616b99452edf1454404df04b5f17 removed `AddExclusionDialog.*` but it's still referenced in 2 files.

Description
-----------


SDK Submodule build
-------------------
#You can change submodule branch here. Default develop.
SDK_SUBMODULE_TEST=develop


Risk area(s)
------------


Tested in
---------
Win | Linux | macOS

