### PR TITLE
Remove references to non-existing files AddExclusionDialog.* and IStatsEventHandler.h

### DIFF
--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -193,7 +193,6 @@ set (FORMS
     ${MEGAsyncDir}/gui/${UiDir}/MegaProgressCustomDialog.ui
     ${MEGAsyncDir}/gui/${UiDir}/PlanWidget.ui
     ${MEGAsyncDir}/gui/${UiDir}/UpgradeDialog.ui
-    ${MEGAsyncDir}/gui/${UiDir}/AddExclusionDialog.ui
     ${MEGAsyncDir}/gui/${UiDir}/StatusInfo.ui
     ${MEGAsyncDir}/gui/${UiDir}/PSAwidget.ui
     ${MEGAsyncDir}/gui/${UiDir}/UpgradeOverStorage.ui
@@ -311,7 +310,6 @@ set (MOC_INPUT
     ${MEGAsyncDir}/control/LoginController.h
     ${MEGAsyncDir}/control/AccountStatusController.h
     ${MEGAsyncDir}/control/EmailRequester.h
-    ${MEGAsyncDir}/control/IStatsEventHandler.h
     ${MEGAsyncDir}/control/ProxyStatsEventHandler.h
     ${MEGAsyncDir}/control/AppStatsEvents.h
 
@@ -324,7 +322,6 @@ set (MOC_INPUT
     ${MEGAsyncDir}/gui/QAlertsModel.h
     ${MEGAsyncDir}/gui/QFilterAlertsModel.h
     ${MEGAsyncDir}/gui/AccountDetailsDialog.h
-    ${MEGAsyncDir}/gui/AddExclusionDialog.h
     ${MEGAsyncDir}/gui/AvatarWidget.h
     ${MEGAsyncDir}/gui/MenuItemAction.h
     ${MEGAsyncDir}/gui/MegaUserAlertExt.h
@@ -622,7 +619,6 @@ set (SRCS
     ${MEGAsyncDir}/gui/AvatarWidget.cpp
     ${MEGAsyncDir}/gui/MenuItemAction.cpp
     ${MEGAsyncDir}/gui/MegaUserAlertExt.cpp
-    ${MEGAsyncDir}/gui/AddExclusionDialog.cpp
     ${MEGAsyncDir}/gui/StatusInfo.cpp
     ${MEGAsyncDir}/gui/ChangePassword.cpp
     ${MEGAsyncDir}/gui/PasswordLineEdit.cpp

--- a/src/MEGASync/control/control.pri
+++ b/src/MEGASync/control/control.pri
@@ -44,7 +44,6 @@ HEADERS  +=  $$PWD/HTTPServer.h \
     $$PWD/DialogOpener.h \
     $$PWD/FileFolderAttributes.h \
     $$PWD/DownloadQueueController.h \
-    $$PWD/IStatsEventHandler.h \
     $$PWD/LinkObject.h \
     $$PWD/LoginController.h \
     $$PWD/Preferences/Preferences.h \

--- a/src/MEGASync/gui/gui.pri
+++ b/src/MEGASync/gui/gui.pri
@@ -38,7 +38,6 @@ SOURCES += $$PWD/SettingsDialog.cpp \
     $$PWD/QMegaMessageBox.cpp \
     $$PWD/AvatarWidget.cpp \
     $$PWD/MenuItemAction.cpp \
-    $$PWD/AddExclusionDialog.cpp \
     $$PWD/StatusInfo.cpp \
     $$PWD/ChangePassword.cpp \
     $$PWD/PSAwidget.cpp \
@@ -138,7 +137,6 @@ HEADERS  += $$PWD/SettingsDialog.h \
     $$PWD/QMegaMessageBox.h \
     $$PWD/AvatarWidget.h \
     $$PWD/MenuItemAction.h \
-    $$PWD/AddExclusionDialog.h \
     $$PWD/StatusInfo.h \
     $$PWD/PSAwidget.h \
     $$PWD/ElidedLabel.h \
@@ -229,7 +227,6 @@ win32 {
                 $$PWD/win/MegaProgressCustomDialog.ui \
                 $$PWD/win/PlanWidget.ui \
                 $$PWD/win/UpgradeDialog.ui \
-                $$PWD/win/AddExclusionDialog.ui \
                 $$PWD/win/StatusInfo.ui \
                 $$PWD/win/PSAwidget.ui \
                 $$PWD/win/RemoteItemUi.ui \
@@ -277,7 +274,6 @@ macx {
                 $$PWD/macx/MegaProgressCustomDialog.ui \
                 $$PWD/macx/PlanWidget.ui \
                 $$PWD/macx/UpgradeDialog.ui \
-                $$PWD/macx/AddExclusionDialog.ui \
                 $$PWD/macx/StatusInfo.ui \
                 $$PWD/macx/PSAwidget.ui \
                 $$PWD/macx/RemoteItemUi.ui\
@@ -348,7 +344,6 @@ unix:!macx {
                 $$PWD/linux/MegaProgressCustomDialog.ui \
                 $$PWD/linux/PlanWidget.ui \
                 $$PWD/linux/UpgradeDialog.ui \
-                $$PWD/linux/AddExclusionDialog.ui \
                 $$PWD/linux/StatusInfo.ui \
                 $$PWD/linux/PSAwidget.ui \
                 $$PWD/linux/UpgradeOverStorage.ui \


### PR DESCRIPTION
Description
-----------
There are files that have been deleted already in previous commits that are still referenced in the make files. These are  AddExclusionDialog.cpp, AddExclusionDialog.h, AddExclusionDialog.ui  and IStatsEventHandler.h.

These missing files are what keeps flathubbot from building the version 5.4, see the following references:
- https://github.com/flathub/nz.mega.MEGAsync/pull/90
- https://buildbot.flathub.org/#/builders/25/builds/17024