### PR TITLE
Set default QT_XCB_GL_INTEGRATION when avoiding Wayland

### DIFF
--- a/src/MEGASync/main.cpp
+++ b/src/MEGASync/main.cpp
@@ -439,6 +439,13 @@ int main(int argc, char *argv[])
         QString sessionType = qEnvironmentVariable("XDG_SESSION_TYPE");
         if (!sessionType.isEmpty() && sessionType == QString::fromUtf8("wayland"))
         {
+            if (!qEnvironmentVariableIsSet("DO_NOT_SET_QT_XCB_GL_INTEGRATION") &&
+                !qEnvironmentVariableIsSet("QT_XCB_GL_INTEGRATION"))
+            {
+                std::cerr << "Setting QT_XCB_GL_INTEGRATION=none" << std::endl;
+                qputenv("QT_XCB_GL_INTEGRATION", "none");
+            }
+
             std::cerr << "Avoiding wayland" << std::endl;
             qunsetenv("XDG_SESSION_TYPE");
         }


### PR DESCRIPTION
Description
-----------


SDK Submodule build
-------------------
#You can change submodule branch here. Default develop.
SDK_SUBMODULE_TEST=develop


Risk area(s)
------------


Tested in
---------
Win | Linux | macOS

