### PR TITLE
linux: improve Wayland dialog surfacing and layout stability

### DIFF
--- a/src/MEGASync/control/DialogOpener.h
+++ b/src/MEGASync/control/DialogOpener.h
@@ -312,6 +312,18 @@ public:
     }
 
     template <class DialogType>
+    static std::shared_ptr<DialogInfo<DialogType>> showDialogWithoutWindowModality(
+        QPointer<DialogType> dialog)
+    {
+        if (dialog)
+        {
+            removeWhenClose(dialog);
+            return showDialogImpl(dialog, false);
+        }
+        return nullptr;
+    }
+
+    template <class DialogType>
     static void showGeometryRetainerDialog(QPointer<DialogType> dialog)
     {
         if(dialog)
@@ -516,6 +528,24 @@ private:
             if (dialog->parent() && changeWindowModality)
             {
                 dialog->setWindowModality(Qt::WindowModal);
+
+                if (auto childWindow = dialog->windowHandle())
+                {
+                    if (auto parentWindow = dialog->parentWidget()->windowHandle())
+                    {
+                        childWindow->setTransientParent(parentWindow);
+                    }
+                }
+            }
+
+            std::shared_ptr<DialogInfoBase> parentInfo;
+            if (dialog->parent())
+            {
+                parentInfo = findDialogInfo(dialog->parent());
+                if (parentInfo)
+                {
+                    parentInfo->raise(true);
+                }
             }
 
             auto geoInfo = mSavedGeometries.value(classType, GeometryInfo());
@@ -563,15 +593,6 @@ private:
                 }
 
                 dialog->show();
-            }
-
-            if (dialog->parent())
-            {
-                auto parentInfo = findDialogInfo(dialog->parent());
-                if (parentInfo)
-                {
-                    parentInfo->raise(true);
-                }
             }
 
             info->raise(true);

--- a/src/MEGASync/gui/onboarding/GuestContent.cpp
+++ b/src/MEGASync/gui/onboarding/GuestContent.cpp
@@ -2,9 +2,14 @@
 
 #include "GuestQmlDialog.h"
 #include "MegaApplication.h"
+#include "DialogOpener.h"
+#include "Onboarding.h"
 #include "QmlDialogManager.h"
+#include "QmlDialogWrapper.h"
 
+#include <QApplication>
 #include <QQmlEngine>
+#include <QTimer>
 
 GuestContent::GuestContent(QObject *parent)
     : QMLComponent(parent)
@@ -16,7 +21,22 @@ GuestContent::GuestContent(QObject *parent)
 void GuestContent::onInitialPageButtonClicked()
 {
 #ifndef WIN32
-    QmlDialogManager::instance()->openOnboardingDialog();
+    DialogOpener::removeDialogByClass<QmlDialogWrapper<GuestContent>>();
+    qApp->processEvents();
+
+    // After logout the previous onboarding wrapper can remain around in a hidden state.
+    // Remove it completely before creating a fresh one, otherwise the close lifecycle can
+    // race the new dialog and make it disappear immediately.
+    DialogOpener::removeDialogByClass<QmlDialogWrapper<Onboarding>>();
+    qApp->processEvents();
+
+    QTimer::singleShot(
+        150,
+        []()
+        {
+            QmlDialogManager::instance()->openOnboardingDialog(true);
+            QmlDialogManager::instance()->raiseOnboardingDialog();
+        });
 #endif
 }
 

--- a/src/MEGASync/gui/onboarding/OnboardingQmlDialog.cpp
+++ b/src/MEGASync/gui/onboarding/OnboardingQmlDialog.cpp
@@ -55,6 +55,11 @@ void OnboardingQmlDialog::forceClose()
 
 void OnboardingQmlDialog::raise()
 {
+    if (Platform::getInstance()->isTilingWindowManager())
+    {
+        setFlags(flags() | Qt::WindowStaysOnTopHint);
+    }
+
     // The following four lines are required by Ubuntu to bring the window to the front and
     // move it to the center of the current screen, if the screen is a part of a virtual desktop or multiple screen
     // we will need add the current screen offset(topleft) to the calculated central position.

--- a/src/MEGASync/gui/qml/QmlDialog.cpp
+++ b/src/MEGASync/gui/qml/QmlDialog.cpp
@@ -1,7 +1,22 @@
 #include "QmlDialog.h"
 
 #include <QEvent>
+#include <QGuiApplication>
 #include <QScreen>
+
+namespace
+{
+bool isHyprlandSession()
+{
+    if (qEnvironmentVariableIsSet("HYPRLAND_INSTANCE_SIGNATURE"))
+    {
+        return true;
+    }
+
+    const auto desktop = qEnvironmentVariable("XDG_CURRENT_DESKTOP");
+    return desktop.contains(QString::fromUtf8("Hyprland"), Qt::CaseInsensitive);
+}
+}
 
 namespace
 {
@@ -64,9 +79,23 @@ void QmlDialog::centerAndRaise()
     int yPos(geometry.y() +
              static_cast<int>(geometry.height() * CENTERING_FACTOR - height() * CENTERING_FACTOR));
 
-    hide();
-    QmlDialog::setPosition(xPos, yPos);
-    show();
+    if (isHyprlandSession())
+    {
+        if (width() <= 1 || height() <= 1)
+        {
+            resize(minimumWidth(), minimumHeight());
+        }
+
+        QmlDialog::showNormal();
+        QmlDialog::setPosition(xPos, yPos);
+        QmlDialog::setVisible(true);
+    }
+    else
+    {
+        hide();
+        QmlDialog::setPosition(xPos, yPos);
+        show();
+    }
 
     // The following two lines are required by Windows (activate) and macOS (raise)
     QmlDialog::requestActivate();

--- a/src/MEGASync/gui/qml/QmlDialogManager.cpp
+++ b/src/MEGASync/gui/qml/QmlDialogManager.cpp
@@ -61,6 +61,26 @@ bool QmlDialogManager::openOnboardingDialog(bool force)
             onboardingInfo->setIgnoreCloseAllAction(true);
         }
     }
+
+    if (auto dialog = DialogOpener::findDialog<QmlDialogWrapper<Onboarding>>())
+    {
+        dialog->show();
+        dialog->getDialog()->activateWindow();
+        dialog->raise();
+
+        if (auto onboardingWindow =
+                dynamic_cast<OnboardingQmlDialog*>(dialog->getDialog()->windowHandle()))
+        {
+            if (onboardingWindow->width() <= 1 || onboardingWindow->height() <= 1)
+            {
+                onboardingWindow->resize(onboardingWindow->minimumWidth(),
+                                         onboardingWindow->minimumHeight());
+            }
+            onboardingWindow->showNormal();
+            onboardingWindow->centerAndRaise();
+        }
+    }
+
     emit openOnboardingDialogSignal();
     return true;
 }
@@ -68,6 +88,14 @@ bool QmlDialogManager::openOnboardingDialog(bool force)
 bool QmlDialogManager::raiseGuestDialog()
 {
     bool raisedGuestDialog = false;
+
+    if (Preferences::instance()->getSession().isEmpty())
+    {
+        openOnboardingDialog(true);
+        raiseOnboardingDialog();
+        return true;
+    }
+
     if (MegaSyncApp->getAccountStatusController()->isAccountBlocked() ||
         (MegaSyncApp->getLoginController() &&
          MegaSyncApp->getLoginController()->getState() != LoginController::FETCH_NODES_FINISHED) ||

--- a/src/MEGASync/gui/qml/QmlDialogWrapper.cpp
+++ b/src/MEGASync/gui/qml/QmlDialogWrapper.cpp
@@ -1,4 +1,6 @@
 #include "QmlDialogWrapper.h"
+#include "Platform.h"
+#include "megaapi.h"
 
 #include <QQmlProperty>
 #include <QWindow>
@@ -6,6 +8,26 @@
 namespace
 {
 const QLatin1String NAMESPACE_SEPARATOR("::");
+
+void surfaceQmlWindow(QPointer<QmlDialog> window)
+{
+    if (!window)
+    {
+        return;
+    }
+
+    if (window->width() <= 1 || window->height() <= 1)
+    {
+        window->resize(window->minimumWidth(), window->minimumHeight());
+    }
+
+    window->showNormal();
+
+    if (!QMetaObject::invokeMethod(window.data(), "raise", Qt::DirectConnection))
+    {
+        window->centerAndRaise();
+    }
+}
 }
 
 // ************************************************************************************************
@@ -166,7 +188,14 @@ void QmlDialogWrapperBase::show()
         mShowDelay.start();
     }
 #else
-    setWindowState(mWindow->windowState());
+    if (Platform::getInstance()->isTilingWindowManager())
+    {
+        surfaceQmlWindow(mWindow);
+    }
+    else
+    {
+        setWindowState(mWindow->windowState());
+    }
 #endif
 }
 
@@ -179,7 +208,14 @@ void QmlDialogWrapperBase::showSync()
     }
 #endif
 
-    setWindowState(mWindow->windowState());
+    if (Platform::getInstance()->isTilingWindowManager())
+    {
+        surfaceQmlWindow(mWindow);
+    }
+    else
+    {
+        setWindowState(mWindow->windowState());
+    }
 }
 
 void QmlDialogWrapperBase::activateWindow()

--- a/src/MEGASync/gui/qml/backups/BackupsDialog.qml
+++ b/src/MEGASync/gui/qml/backups/BackupsDialog.qml
@@ -14,7 +14,7 @@ SyncsQmlDialog {
     id: window
 
     title: BackupsStrings.backupsWindowTitle
-    visible: false
+    flags: Qt.Window | Qt.WindowTitleHint | Qt.WindowCloseButtonHint
     modality: Qt.NonModal
     width: 640
     height: 403

--- a/src/MEGASync/gui/qml/backups/ConfirmTable.qml
+++ b/src/MEGASync/gui/qml/backups/ConfirmTable.qml
@@ -17,9 +17,7 @@ Rectangle {
     readonly property int headerHeight: 40
     readonly property int tableRadius: 8
 
-    Layout.preferredWidth: width
-    Layout.preferredHeight: height
-    width: 400
+    implicitHeight: 184
     height: 184
     radius: tableRadius
     color: ColorTheme.pageBackground

--- a/src/MEGASync/gui/qml/backups/ResumePageForm.ui.qml
+++ b/src/MEGASync/gui/qml/backups/ResumePageForm.ui.qml
@@ -44,7 +44,7 @@ FooterButtonsPage {
         Texts.Text {
             id: titleItem
 
-            Layout.preferredWidth: parent.width
+            Layout.fillWidth: true
             Layout.topMargin: 40
             text: BackupsStrings.finalStepBackupTitle
             font {
@@ -57,7 +57,7 @@ FooterButtonsPage {
         Texts.SecondaryText {
             id: descriptionItem
 
-            Layout.preferredWidth: parent.width
+            Layout.fillWidth: true
             text: BackupsStrings.finalStepBackup
             font.pixelSize: Texts.Text.Size.MEDIUM
             wrapMode: Text.Wrap
@@ -68,7 +68,7 @@ FooterButtonsPage {
         Texts.SecondaryText {
             id: descriptionItem2
 
-            Layout.preferredWidth: parent.width
+            Layout.fillWidth: true
             text: BackupsStrings.finalStepBackup2
             font.pixelSize: Texts.Text.Size.MEDIUM
             wrapMode: Text.Wrap

--- a/src/MEGASync/gui/qml/backups/SelectTable.qml
+++ b/src/MEGASync/gui/qml/backups/SelectTable.qml
@@ -19,10 +19,6 @@ Item {
     readonly property int headerFooterHeight: 40
     readonly property int tableRadius: 8
 
-    Layout.preferredWidth: parent.width
-    Layout.preferredHeight: height
-    width: parent.width
-
     Rectangle {
         id: backgroundRectangle
 

--- a/src/MEGASync/gui/qml/components/buttons/Button.qml
+++ b/src/MEGASync/gui/qml/components/buttons/Button.qml
@@ -1,8 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15 as Qml
 import QtQuick.Layouts 1.15
-import QtGraphicalEffects 1.15
-
 import common 1.0
 
 import components.texts 1.0 as Texts
@@ -173,26 +171,9 @@ Qml.RoundButton {
             }
             radius: sizes.radius
             color: getBackgroundColor()
-            layer {
-                enabled: true
-                effect: OpacityMask {
-                    id: mask
-
-                    maskSource: Item {
-                        width: backgroundRect.width
-                        height: backgroundRect.height
-
-                        Rectangle {
-                            id: maskRect
-
-                            anchors.centerIn: parent
-                            width:  backgroundRect.width
-                            height: backgroundRect.height
-                            radius: sizes.radius
-                        }
-                    }
-                }
-            }
+            // GraphicalEffects-based masking renders unreliably with the Linux software
+            // backend. Plain clipping keeps the rounded button visible on Hyprland.
+            clip: true
 
             Progress {
                 id: backgroundProgress

--- a/src/MEGASync/gui/qml/onboard/LoginPage.qml
+++ b/src/MEGASync/gui/qml/onboard/LoginPage.qml
@@ -223,7 +223,8 @@ LoginPageForm {
 
         function onLogout() {
             password.text = "";
-            window.forceClose();
+            // After logout we want the login window to remain usable if it is opened from the
+            // guest tray flow. Force-closing it here races that flow and makes the dialog flash.
         }
     }
 

--- a/src/MEGASync/gui/qml/syncs/ChooseSyncFolder.qml
+++ b/src/MEGASync/gui/qml/syncs/ChooseSyncFolder.qml
@@ -25,9 +25,8 @@ FocusScope {
 
     signal buttonClicked
 
-    width: parent.width
     height: folderItem.height
-    Layout.preferredWidth: width
+    Layout.fillWidth: true
     Layout.preferredHeight: folderItem.height
 
     TextField {

--- a/src/MEGASync/gui/qml/syncs/ResumeSyncsPageForm.ui.qml
+++ b/src/MEGASync/gui/qml/syncs/ResumeSyncsPageForm.ui.qml
@@ -47,7 +47,7 @@ FooterButtonsPage {
         Texts.Text {
             id: titleItem
 
-            Layout.preferredWidth: parent.width
+            Layout.fillWidth: true
             Layout.topMargin: 40
             text: SyncsStrings.finalStepSyncTitle
             font {
@@ -61,7 +61,7 @@ FooterButtonsPage {
             id: descriptionItem
 
             Layout.topMargin: 30
-            Layout.preferredWidth: parent.width
+            Layout.fillWidth: true
             text: SyncsStrings.finalStepSync
             font.pixelSize: Texts.Text.Size.MEDIUM
             wrapMode: Text.Wrap

--- a/src/MEGASync/gui/qml/syncs/SelectiveSyncPageForm.ui.qml
+++ b/src/MEGASync/gui/qml/syncs/SelectiveSyncPageForm.ui.qml
@@ -48,14 +48,14 @@ FooterButtonsPage {
 
 
         ColumnLayout {
-            Layout.preferredWidth: parent.width
+            Layout.fillWidth: true
             spacing: (localFolder.folderField.hint.visible && remoteFolder.folderField.hint.visible) ?
                          textSpacings / 4
                        : textSpacings
             HeaderTexts {
                 id: header
 
-                Layout.preferredWidth: parent.width
+                Layout.fillWidth: true
                 title: SyncsStrings.selectiveSyncTitle
                 description: SyncsStrings.selectiveSyncDescription
             }
@@ -73,7 +73,7 @@ FooterButtonsPage {
         }
 
         ColumnLayout {
-            Layout.preferredWidth: parent.width
+            Layout.fillWidth: true
             spacing: Constants.defaultComponentSpacing
                      - (localFolder.folderField.hint.visible + remoteFolder.folderField.hint.visible)
                         * Constants.defaultComponentSpacing / 2.5
@@ -84,8 +84,7 @@ FooterButtonsPage {
                 title: SyncsStrings.selectLocalFolder
                 leftIconSource: Images.pc
                 chosenPath: syncsDataAccess.defaultLocalFolder
-                Layout.preferredWidth: parent.width + 8
-                Layout.leftMargin: -4
+                Layout.fillWidth: true
             }
 
             ChooseSyncFolder {
@@ -94,8 +93,7 @@ FooterButtonsPage {
                 title: SyncsStrings.selectMEGAFolder
                 leftIconSource: Images.megaOutline
                 chosenPath: syncsDataAccess.defaultRemoteFolder
-                Layout.preferredWidth: parent.width + 8
-                Layout.leftMargin: -4
+                Layout.fillWidth: true
             }
         }
     }

--- a/src/MEGASync/gui/qml/syncs/SyncsDialog.qml
+++ b/src/MEGASync/gui/qml/syncs/SyncsDialog.qml
@@ -11,7 +11,7 @@ SyncsQmlDialog {
     id: window
 
     title: SyncsStrings.syncsWindowTitle
-    visible: false
+    flags: Qt.Window | Qt.WindowTitleHint | Qt.WindowCloseButtonHint
     modality: Qt.NonModal
     width: 640
     height: 402

--- a/src/MEGASync/gui/syncs/SyncsQmlDialog.cpp
+++ b/src/MEGASync/gui/syncs/SyncsQmlDialog.cpp
@@ -5,15 +5,50 @@
 #include "SyncInfo.h"
 
 #include <QEvent>
+#include <QScreen>
+#include <QString>
+
+namespace
+{
+constexpr double CENTERING_FACTOR = 0.5;
+}
+
+void SyncsQmlDialog::raise()
+{
+    setFlags((flags() & ~Qt::Dialog) | Qt::Window | Qt::WindowTitleHint |
+             Qt::WindowCloseButtonHint);
+    setModality(Qt::NonModal);
+
+    const int targetWidth = qMax(width(), minimumWidth());
+    const int targetHeight = qMax(height(), minimumHeight());
+    const auto& geometry = screen()->geometry();
+    const int xPos = geometry.x() +
+                     static_cast<int>(geometry.width() * CENTERING_FACTOR -
+                                      targetWidth * CENTERING_FACTOR);
+    const int yPos = geometry.y() +
+                     static_cast<int>(geometry.height() * CENTERING_FACTOR -
+                                      targetHeight * CENTERING_FACTOR);
+
+    setMinimumWidth(targetWidth);
+    setMinimumHeight(targetHeight);
+    setGeometry(xPos, yPos, targetWidth, targetHeight);
+    setVisible(true);
+    showNormal();
+    resize(targetWidth, targetHeight);
+
+    requestActivate();
+    QmlDialog::raise();
+}
 
 bool SyncsQmlDialog::event(QEvent* event)
 {
-    if (event->type() == QEvent::Close || event->type() == QEvent::Show)
+    if (event->type() == QEvent::Close || event->type() == QEvent::Show ||
+        event->type() == QEvent::Hide)
     {
         if (auto dialog = DialogOpener::findDialog<SettingsDialog>())
         {
             dialog->getDialog()->setSyncAddButtonEnabled(
-                event->type() == QEvent::Close,
+                event->type() != QEvent::Show,
                 isBackup() ? SettingsDialog::Tabs::BACKUP_TAB : SettingsDialog::Tabs::SYNCS_TAB);
         }
 

--- a/src/MEGASync/gui/syncs/SyncsQmlDialog.h
+++ b/src/MEGASync/gui/syncs/SyncsQmlDialog.h
@@ -15,6 +15,7 @@ public:
 
     bool isBackup() const;
     void setIsBackup(bool newIsBackup);
+    Q_INVOKABLE void raise();
 
 protected:
     bool event(QEvent*) override;

--- a/src/MEGASync/syncs/control/CreateRemoveBackupsManager.cpp
+++ b/src/MEGASync/syncs/control/CreateRemoveBackupsManager.cpp
@@ -3,7 +3,48 @@
 #include "BackupCandidatesComponent.h"
 #include "DialogOpener.h"
 #include "QmlDialogWrapper.h"
+#include "QmlDialog.h"
+#include "SyncsQmlDialog.h"
 #include "SyncSettings.h"
+
+#include <QPointer>
+#include <QTimer>
+
+namespace
+{
+void surfaceBackupsDialog(QPointer<QmlDialogWrapper<BackupCandidatesComponent>> dialog)
+{
+    if (!dialog)
+    {
+        return;
+    }
+
+    dialog->show();
+    dialog->activateWindow();
+    dialog->raise();
+
+    if (auto backupsWindow = dynamic_cast<SyncsQmlDialog*>(dialog->windowHandle()))
+    {
+        if (backupsWindow->width() <= 1 || backupsWindow->height() <= 1)
+        {
+            backupsWindow->resize(backupsWindow->minimumWidth(), backupsWindow->minimumHeight());
+        }
+
+        backupsWindow->showNormal();
+        backupsWindow->raise();
+    }
+}
+
+void queueBackupsDialogSurface(QPointer<QmlDialogWrapper<BackupCandidatesComponent>> dialog)
+{
+    QTimer::singleShot(
+        0,
+        [dialog]()
+        {
+            surfaceBackupsDialog(dialog);
+        });
+}
+}
 
 void CreateRemoveBackupsManager::addBackup(SyncInfo::SyncOrigin origin,
                                            const QStringList& localFolders)
@@ -60,5 +101,13 @@ void CreateRemoveBackupsManager::showBackupDialog(SyncInfo::SyncOrigin origin,
         backupsDialog->wrapper()->insertFolders(localFolders);
     }
 
-    DialogOpener::showDialog(backupsDialog);
+    if (origin == SyncInfo::SyncOrigin::SETTINGS_ORIGIN)
+    {
+        DialogOpener::showDialogWithoutWindowModality(backupsDialog);
+    }
+    else
+    {
+        DialogOpener::showDialog(backupsDialog);
+    }
+    queueBackupsDialogSurface(backupsDialog);
 }

--- a/src/MEGASync/syncs/control/CreateRemoveSyncsManager.cpp
+++ b/src/MEGASync/syncs/control/CreateRemoveSyncsManager.cpp
@@ -2,10 +2,51 @@
 
 #include "DialogOpener.h"
 #include "QmlDialogWrapper.h"
+#include "QmlDialog.h"
 #include "RemoveSyncConfirmationDialog.h"
 #include "SyncController.h"
 #include "SyncsComponent.h"
+#include "SyncsQmlDialog.h"
 #include "SyncSettings.h"
+
+#include <QPointer>
+#include <QTimer>
+
+namespace
+{
+void surfaceSyncsDialog(QPointer<QmlDialogWrapper<SyncsComponent>> dialog)
+{
+    if (!dialog)
+    {
+        return;
+    }
+
+    dialog->show();
+    dialog->activateWindow();
+    dialog->raise();
+
+    if (auto syncsWindow = dynamic_cast<SyncsQmlDialog*>(dialog->windowHandle()))
+    {
+        if (syncsWindow->width() <= 1 || syncsWindow->height() <= 1)
+        {
+            syncsWindow->resize(syncsWindow->minimumWidth(), syncsWindow->minimumHeight());
+        }
+
+        syncsWindow->showNormal();
+        syncsWindow->raise();
+    }
+}
+
+void queueSyncsDialogSurface(QPointer<QmlDialogWrapper<SyncsComponent>> dialog)
+{
+    QTimer::singleShot(
+        0,
+        [dialog]()
+        {
+            surfaceSyncsDialog(dialog);
+        });
+}
+}
 
 void CreateRemoveSyncsManager::addSync(SyncInfo::SyncOrigin origin,
                                        mega::MegaHandle handle,
@@ -104,5 +145,13 @@ void CreateRemoveSyncsManager::showSyncDialog(SyncInfo::SyncOrigin origin,
         syncsDialog->wrapper()->setLocalFolder(localFolder);
     }
 
-    DialogOpener::showDialog(syncsDialog);
+    if (origin == SyncInfo::SyncOrigin::SETTINGS_ORIGIN)
+    {
+        DialogOpener::showDialogWithoutWindowModality(syncsDialog);
+    }
+    else
+    {
+        DialogOpener::showDialog(syncsDialog);
+    }
+    queueSyncsDialogSurface(syncsDialog);
 }


### PR DESCRIPTION
  Summary
  - improve surfacing/raising of QML dialogs on Wayland and tiling WMs
  - fix add-sync / add-backup dialog visibility problems
  - remove QML layout feedback loops that made these dialogs unstable

  Problem
  Several QML dialogs were created successfully but could still end up hidden,
  collapsed, or otherwise unusable under Hyprland/Wayland. The most visible cases
  were:
  - Add sync
  - Add backup
  - onboarding-related dialog flows

  There were two separate issues:
  1. dialog surfacing and parenting paths were too fragile for this environment
  2. some QML pages had layout bindings that caused recursive rearrange / polish
     loop failures

  Fix
  - improve dialog opener and wrapper behavior for these QML dialogs
  - add explicit raise/surfacing paths where needed
  - adjust sync/backups dialog handling and modality
  - remove conflicting width/height/layout bindings from affected QML pages

  Tested on
  - NixOS 26.05
  - Hyprland
  - Qt 5.15